### PR TITLE
Setting a hard limit for nb_points in profile

### DIFF
--- a/alti/lib/validation/profile.py
+++ b/alti/lib/validation/profile.py
@@ -64,12 +64,13 @@ class ProfileValidation(object):
     @nb_points.setter
     def nb_points(self, value):
         if value is None:
-            self._nb_points = 200
+            self._nb_points = self.nb_points_default
         else:
-            if value.isdigit():
+            if value.isdigit() and int(value) <= self.nb_points_max:
                 self._nb_points = int(value)
             else:
-                raise HTTPBadRequest("Please provide a numerical value for the parameter 'NbPoints'/'nb_points'")
+                raise HTTPBadRequest("Please provide a numerical value for the parameter 'NbPoints'/'nb_points'" +
+                            " smaller than {}".format(self.nb_points_max))
 
     @ma_offset.setter
     def ma_offset(self, value):

--- a/alti/tests/integration/test_profile.py
+++ b/alti/tests/integration/test_profile.py
@@ -71,6 +71,7 @@ class TestProfileView(TestsBase):
         params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}', 'nb_points': '150'}
         resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
+        self.assertEqual(len(resp.json), 151)
 
     def test_profile_json_simplify_linestring(self):
         params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}', 'nb_points': '1'}
@@ -86,6 +87,17 @@ class TestProfileView(TestsBase):
         params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}', 'nb_points': 'toto'}
         resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=400)
         resp.mustcontain("Please provide a numerical value for the parameter 'NbPoints'/'nb_points'")
+
+    def test_profile_json_nb_points_too_much(self):
+        params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}', 'nb_points': '1000000'}
+        resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=400)
+        resp.mustcontain("Please provide a numerical value for the parameter 'NbPoints'/'nb_points'")
+
+    def test_profile_json_default_nb_points(self):
+        params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}'}
+        resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=200)
+        pnts = resp.json
+        self.assertEqual(len(pnts), 201)
 
     def test_profile_csv_valid(self):
         params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}'}

--- a/alti/views/profile.py
+++ b/alti/views/profile.py
@@ -11,6 +11,8 @@ class Profile(ProfileValidation):
 
     def __init__(self, request):
         super(Profile, self).__init__()
+        self.nb_points_default = int(request.registry.settings.get('profile_nb_points_default', 200))
+        self.nb_points_max = int(request.registry.settings.get('profile_nb_points_maximum', 500))
         self.linestring = request.params.get('geom')
         if 'layers' in request.params:
             self.layers = request.params.get('layers')

--- a/production.ini.in
+++ b/production.ini.in
@@ -27,6 +27,9 @@ apache_entry_path = ${apache_entry_path}
 address_search_referers = localhost,admin.ch,awk.ch,cadastre.ch,rspp.ch,rollstuhlparkplatz.ch,placehandicape.ch,parcheggiodisabili.chi,zh.ch
 http_proxy = ${http_proxy}
 
+profile_nb_points_default = 200
+profile_nb_points_maximum = 500
+
 ###
 # wsgi server configuration
 ###


### PR DESCRIPTION

Currently, if you set *nb_points* to 500, you effectively get *500* points. This PR defines a *default* and *max value* for *nb_points*.

Current situation (integration)
 ```
$ curl -s -H "Referer: http://toto.admin.ch" -H "Content-Type: application/json" \
 "http://service-alti.int.bgdi.ch/rest/services/profile.json?geom=%7B%22type%22%3A%22LineString%22%2C%22coordinates%22%3A%5B%5B550050%2C206550%5D%2C%5B556950%2C204150%5D%2C%5B561050%2C207950%5D%5D%7D&nb_points=600" | jq '.'[].dist | wc -l

601
```

With this PR (/ltmom)
```
$ curl -s -I -H "Referer: http://toto.admin.ch" -H "Content-Type: application/json"  "http://service-alti.dev.bgdi.ch/ltmom/rest/services/profile.json?geom=%7B%22type%22%3A%22LineString%22%2C%22coordinates%22%3A%5B%5B550050%2C206550%5D%2C%5B556950%2C204150%5D%2C%5B561050%2C207950%5D%5D%7D&nb_points=600"
HTTP/1.1 400 Bad Request

```