### PR TITLE
Issue with install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ production.ini: production.ini.in
 	@echo "${GREEN}Installing git hooks${RESET}";
 	./scripts/install-git-hooks.sh
 	touch $@
-
+ 
 requirements.txt:
 	@echo "${GREEN}File requirements.txt has changed${RESET}";
 .venv: requirements.txt
@@ -246,9 +246,12 @@ requirements.txt:
 	@if [ ! -d $(INSTALL_DIRECTORY) ]; \
 	then \
 		virtualenv $(INSTALL_DIRECTORY); \
-		${PIP_CMD} install -U pip; \
+		${PIP_CMD} install ${CURRENT_DIRECTORY}/pip-8.1.2.tar.gz; \
+		${PIP_CMD} install -U pip distribute; \
+		${PIP_CMD} install setuptools==36.6.0;  \
+		${PIP_CMD} install pyopenssl ndg-httpsclient pyasn1; \
 	fi
-	${PYTHON_CMD} setup.py develop
+	${PIP_CMD} install -e .
 
 .venv/bin/git-secrets: .venv
 	@echo "${GREEN}Installing git secrets${RESET}";

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 autopep8==1.2.4
 coverage==4.1
-flake8==3.0.0
+flake8==2.6.2
 geojson==1.3.4
 Mako==1.0.0
 nose==1.3.7
@@ -12,4 +12,4 @@ six==1.5.0
 waitress==0.9.0
 WebOb==1.6.1
 WebTest==2.0.21
-zope.interface==4.2.0
+zope.interface==4.3.3


### PR DESCRIPTION
Due to some certificat issue, we cannot install with the distribution pip anymore.

Install modern pip from local, additional python module for SSL issue, and revert to older flake8