### PR TITLE
Debugging for big linestring, limit geom size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ MANIFEST
 buildout_branch.cfg
 deploy/deploy-branch.cfg
 deploy/conf/00-branch.conf
+payload.json
+result_payload.json

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,7 @@ apache/wsgi.conf: apache/wsgi.conf.in apache/application.wsgi
 		--var "current_directory=$(CURRENT_DIRECTORY)" \
 		--var "modwsgi_user=$(MODWSGI_USER)" \
 		--var "wsgi_threads=$(WSGI_THREADS)" \
+		--var "wsgi_processes=$(WSGI_PROCESSES)" \
 		--var "wsgi_app=$(WSGI_APP)" $< > $@
 
 development.ini.in:
@@ -238,7 +239,7 @@ production.ini: production.ini.in
 	@echo "${GREEN}Installing git hooks${RESET}";
 	./scripts/install-git-hooks.sh
 	touch $@
- 
+
 requirements.txt:
 	@echo "${GREEN}File requirements.txt has changed${RESET}";
 .venv: requirements.txt

--- a/alti/lib/validation/profile.py
+++ b/alti/lib/validation/profile.py
@@ -24,7 +24,11 @@ class ProfileValidation(object):
         sr = None
         if self.linestring is not None:
             for epsg, bbox in bboxes.iteritems():
-                dtm_poly = Polygon([(bbox[0], bbox[1]), (bbox[2], bbox[1]), (bbox[2], bbox[3]), (bbox[0], bbox[3])])
+                dtm_poly = Polygon([
+                    (bbox[0], bbox[1]),
+                    (bbox[2], bbox[1]),
+                    (bbox[2], bbox[3]),
+                    (bbox[0], bbox[3])])
                 if dtm_poly.contains(self.linestring):
                     sr = epsg
                     break

--- a/alti/subscribers.py
+++ b/alti/subscribers.py
@@ -1,15 +1,21 @@
 # -*- coding: utf-8 -*-
 
 from pyramid.events import subscriber, NewRequest
-from pyramid.httpexceptions import HTTPRequestEntityTooLarge
+from pyramid.httpexceptions import HTTPBadRequest, HTTPRequestEntityTooLarge
 
 
 @subscriber(NewRequest)
 def validate_body_length(event):
+    content_length = 0
     max_clength = 160000
-    content_length = event.request.headers.get('Content-Length')
-    content_length = content_length or len(event.request.params.get('geom', ''))
-    if content_length and int(content_length) > max_clength:
+    if event.request.method == 'POST':
+        content_length = event.request.headers.get('Content-Length')
+        if not content_length:
+            raise HTTPBadRequest('No Content-Length was provided in request header')  # pragam: no cover
+    elif event.request.method == 'GET':
+        content_length = len(event.request.params.get('geom', ''))
+
+    if int(content_length) > max_clength:
         raise HTTPRequestEntityTooLarge(
             'LineString too large, maximum Content-Length ' +
             'of %s exceeded' % max_clength

--- a/alti/subscribers.py
+++ b/alti/subscribers.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+from pyramid.events import subscriber, NewRequest
+from pyramid.httpexceptions import HTTPRequestEntityTooLarge
+
+
+@subscriber(NewRequest)
+def validate_body_length(event):
+    max_clength = 160000
+    content_length = event.request.headers.get('Content-Length')
+    content_length = content_length or len(event.request.params.get('geom', ''))
+    if content_length and int(content_length) > max_clength:
+        raise HTTPRequestEntityTooLarge(
+            'LineString too large, maximum Content-Length ' +
+            'of %s exceeded' % max_clength
+        )

--- a/alti/tests/integration/test_profile.py
+++ b/alti/tests/integration/test_profile.py
@@ -6,20 +6,24 @@ from shapely.geometry import Point, LineString, mapping
 from alti.tests.integration import TestsBase
 
 
-def generate_random_coord():
-    minx, miny = 2650000, 1200000
-    maxx, maxy = 2750000, 1280000
+def generate_random_coord(srid):
+    if srid == 2056:
+        minx, miny = 2650000, 1200000
+        maxx, maxy = 2750000, 1280000
+    else:
+        minx, miny = 650000, 200000
+        maxx, maxy = 750000, 280000
     yield random.randint(minx, maxx), random.randint(miny, maxy)
 
 
-def generate_random_point(nb_pts):
+def generate_random_point(nb_pts, srid):
     for i in xrange(nb_pts):
-        for x, y in generate_random_coord():
+        for x, y in generate_random_coord(srid):
             yield Point(x, y)
 
 
-def create_json(nb_pts):
-    line = LineString([p for p in generate_random_point(nb_pts)])
+def create_json(nb_pts, srid=2056):
+    line = LineString([p for p in generate_random_point(nb_pts, srid)])
     return json.dumps(mapping(line))
 
 
@@ -30,17 +34,18 @@ class TestProfileView(TestsBase):
         self.headers = {'X-SearchServer-Authorized': 'true'}
 
     def test_profile_no_sr_json_valid(self):
-        self.testapp.get('/rest/services/profile.json', params={'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}'}, headers=self.headers, status=200)
+        self.testapp.get('/rest/services/profile.json', params={'geom': create_json(3, 21781)}, headers=self.headers, status=200)
 
     def test_profile_invalide_sr_json_valid(self):
-        resp = self.testapp.get('/rest/services/profile.json', params={'sr': 666, 'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}'}, headers=self.headers, status=400)
+        resp = self.testapp.get('/rest/services/profile.json', params={'sr': 666, 'geom': create_json(3, 21781)}, headers=self.headers, status=400)
         resp.mustcontain("Please provide a valid number for the spatial reference system model 21781 or 2056")
 
     def test_profile_lv95_json_valid(self):
-        self.testapp.get('/rest/services/profile.json', params={'sr': 2056, 'geom': '{"type":"LineString","coordinates":[[2550050,1206550],[2556950,1204150],[2561050,1207950]]}'}, headers=self.headers, status=200)
+        self.testapp.get('/rest/services/profile.json', params={'sr': 2056, 'geom': create_json(4, 2056)}, headers=self.headers, status=200)
 
     def test_profile_lv03_json_valid(self):
-        resp = self.testapp.get('/rest/services/profile.json', params={'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}'}, headers=self.headers, status=200)
+        params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}'}
+        resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(resp.json[0]['dist'], 0)
         self.assertEqual(resp.json[0]['alts']['DTM25'], 1138)
@@ -58,8 +63,15 @@ class TestProfileView(TestsBase):
         self.assertEqual(resp.json[0]['northing'], 206550)
 
     def test_profile_lv03_layers(self):
-        params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}', 'layers': 'DTM25,DTM2'}
+        params = {'geom': create_json(4, 21781), 'layers': 'DTM25,DTM2'}
         resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=200)
+        self.assertEqual(resp.content_type, 'application/json')
+
+    def test_profile_lv03_layers_post(self):
+        params = {'geom': create_json(4, 21781), 'layers': 'DTM25,DTM2'}
+        content_type, body = self.testapp.encode_multipart(params.iteritems(), [])
+        self.headers['Content-Type'] = str(content_type)
+        resp = self.testapp.post('/rest/services/profile.json', body, headers=self.headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
 
     def test_profile_lv03_layers_none(self):
@@ -73,12 +85,12 @@ class TestProfileView(TestsBase):
         resp.mustcontain("No 'sr' given and cannot be guessed from 'geom'")
 
     def test_profile_lv03_json_2_models_notvalid(self):
-        params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}', 'elevation_models': 'DTM25,DTM222'}
+        params = {'geom': create_json(4, 21781), 'elevation_models': 'DTM25,DTM222'}
         resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=400)
         resp.mustcontain('Please provide a valid name for the elevation model DTM25, DTM2 or COMB')
 
     def test_profile_lv03_json_with_callback_valid(self):
-        params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}', 'callback': 'cb_'}
+        params = {'geom': create_json(4, 21781), 'callback': 'cb_'}
         resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=200)
         self.assertEqual(resp.content_type, 'application/javascript')
         resp.mustcontain('cb_([')
@@ -104,22 +116,22 @@ class TestProfileView(TestsBase):
         self.assertEqual(len(resp.json), 151)
 
     def test_profile_lv03_json_simplify_linestring(self):
-        params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}', 'nb_points': '1'}
+        params = {'geom': create_json(4, 21781), 'nb_points': '1'}
         resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
 
     def test_profile_lv03_json_nbPoints(self):
-        params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}', 'nbPoints': '150'}
+        params = {'geom': create_json(4, 21781), 'nbPoints': '150'}
         resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
 
     def test_profile_lv03_json_nb_points_wrong(self):
-        params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}', 'nb_points': 'toto'}
+        params = {'geom': create_json(4, 21781), 'nb_points': 'toto'}
         resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=400)
         resp.mustcontain("Please provide a numerical value for the parameter 'NbPoints'/'nb_points'")
 
     def test_profile_lv03_json_nb_points_too_much(self):
-        params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}', 'nb_points': '1000000'}
+        params = {'geom': create_json(4, 21781), 'nb_points': '1000000'}
         resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=400)
         resp.mustcontain("Please provide a numerical value for the parameter 'NbPoints'/'nb_points'")
 
@@ -130,7 +142,7 @@ class TestProfileView(TestsBase):
         self.assertEqual(len(pnts), 201)
 
     def test_profile_lv03_csv_valid(self):
-        params = {'geom': '{"type":"LineString","coordinates":[[550050,206550],[556950,204150],[561050,207950]]}'}
+        params = {'geom': create_json(4, 21781)}
         resp = self.testapp.get('/rest/services/profile.csv', params=params, headers=self.headers, status=200)
         self.assertEqual(resp.content_type, 'text/csv')
 
@@ -145,7 +157,8 @@ class TestProfileView(TestsBase):
         resp.mustcontain('Error converting JSON to Shape')
 
     def test_profile_lv03_json_invalid_linestring(self):
-        resp = self.testapp.get('/rest/services/profile.json', params={'geom': '{"type":"LineString","coordinates":[[550050,206550]]}'}, headers=self.headers, status=400)
+        params = {'geom': '{"type":"LineString","coordinates":[[550050,206550]]}'}
+        resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=400)
         resp.mustcontain('Invalid Linestring syntax')
 
     def test_profile_lv03_json_offset(self):
@@ -161,4 +174,11 @@ class TestProfileView(TestsBase):
     def test_profile_entity_too_large(self):
         params = {'geom': create_json(7000), 'sr': '2056'}
         resp = self.testapp.get('/rest/services/profile.json', params=params, headers=self.headers, status=413)
+        resp.mustcontain('LineString too large')
+
+    def test_profile_entity_too_large_post(self):
+        params = {'geom': create_json(7000), 'sr': '2056'}
+        content_type, body = self.testapp.encode_multipart(params.iteritems(), [])
+        self.headers['Content-Type'] = str(content_type)
+        resp = self.testapp.post('/rest/services/profile.json', body, headers=self.headers, status=413)
         resp.mustcontain('LineString too large')

--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -45,7 +45,7 @@ RewriteRule ^${apache_entry_path}/robots.txt ${apache_entry_path}/static/robots.
 
 # define a process group
 # WSGIDaemonProcess, default are 1 process and 15 threads
-WSGIDaemonProcess service-alti:${apache_base_path} display-name=%{GROUP} user=${modwsgi_user} threads=${wsgi_threads}
+WSGIDaemonProcess service-alti:${apache_base_path} display-name=%{GROUP} user=${modwsgi_user} processes=${wsgi_processes} threads=${wsgi_threads}
 
 # define the path to the WSGI app
 WSGIScriptAliasMatch ^${apache_entry_path}/ ${wsgi_app}/

--- a/rc_dev
+++ b/rc_dev
@@ -5,3 +5,4 @@ export KEEP_VERSION=false
 export MODWSGI_CONFIG=production.ini
 export SERVER_PORT=6543
 export WSGI_THREADS=15
+export WSGI_PROCESSES=1

--- a/rc_int
+++ b/rc_int
@@ -5,3 +5,4 @@ export KEEP_VERSION=true
 export MODWSGI_CONFIG=production.ini
 export SERVER_PORT=6543
 export WSGI_THREADS=15
+export WSGI_PROCESSES=1

--- a/rc_prod
+++ b/rc_prod
@@ -5,4 +5,5 @@ export KEEP_VERSION=true
 export MODWSGI_CONFIG=production.ini
 export PRINT_WAR=main
 export SERVER_PORT=6543
-export WSGI_THREADS=30
+export WSGI_THREADS=15
+export WSGI_PROCESSES=4

--- a/scripts/generate-linestring.py
+++ b/scripts/generate-linestring.py
@@ -1,0 +1,14 @@
+import sys
+from alti.tests.integration.test_profile import create_line
+
+
+def main():
+    if len(sys.argv) != 2 or not sys.argv[1].isdigit():
+        sys.exit(1)
+    nb_pts = int(sys.argv[1])
+    with open('payload.json', 'w+') as f:
+        f.write(create_line(nb_pts))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/test-payload.sh
+++ b/scripts/test-payload.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source .venv/bin/activate
+python scripts/generate-linestring.py 5000
+PAYLOAD=$(cat payload.json)
+curl -F "geom=${PAYLOAD}" \
+     -F "elevation_models=COMB" \
+     -H "Referer: https://map.geo.admin.ch" \
+     -vv http://service-alti.dev.bgdi.ch/rest/services/profile.json > result_payload.json
+
+#curl -F "geom=@payload.json" \
+#     http://localhost:9000/rest/services/profile.json


### PR DESCRIPTION
Evaluation for https://github.com/geoadmin/mf-chsdi3/issues/2702

`./scripts/test-payload.sh`

5300 coordinates is still fine but it takes up to 10 sec.
It seems that blocking at 150'000 content length would already be quite permissive. do you agree?
ping @gjn @davidoesch 

`Content-Length: 127487`

Then I have to find out why the `@` notation with curl doesn't work. Body is too big to be passed as a string to curl beyond that.

ping @procrastinatio could you give me a hint?
I would like to block it at Apache level.

https://github.com/geoadmin/mf-chsdi3/issues/2702