### PR TITLE
use exact points from KML

### DIFF
--- a/alti/lib/validation/profile.py
+++ b/alti/lib/validation/profile.py
@@ -6,6 +6,8 @@ from pyramid.httpexceptions import HTTPBadRequest
 from shapely.geometry import asShape, Polygon
 
 
+DEFAULT_OFFSET = 0
+
 bboxes = {
     2056: (2450000, 1030000, 2900000, 1350000),
     21781: (450000, 30000, 900000, 350000)
@@ -105,7 +107,7 @@ class ProfileValidation(object):
     @ma_offset.setter
     def ma_offset(self, value):
         if value is None:
-            self._ma_offset = 3
+            self._ma_offset = DEFAULT_OFFSET
         else:
             if value.isdigit():
                 self._ma_offset = int(value)

--- a/alti/views/profile.py
+++ b/alti/views/profile.py
@@ -15,7 +15,7 @@ class Profile(ProfileValidation):
     def __init__(self, request):
         super(Profile, self).__init__()
         self.nb_points_default = int(request.registry.settings.get('profile_nb_points_default', 200))
-        self.nb_points_max = int(request.registry.settings.get('profile_nb_points_maximum', 500))
+        self.nb_points_max = int(request.registry.settings.get('profile_nb_points_maximum', 1000))
         self.linestring = request.params.get('geom')
         if 'layers' in request.params:
             self.layers = request.params.get('layers')
@@ -32,6 +32,8 @@ class Profile(ProfileValidation):
             if sr is None:
                 raise HTTPBadRequest("No 'sr' given and cannot be guessed from 'geom'")
             self.sr = sr
+        if len(self.linestring.coords) > self.nb_points_max:
+            raise HTTPBadRequest("Input LineString has more coordinates than {}".format(self.nb_points_max))
         self.ma_offset = request.params.get('offset')
         self.request = request
 

--- a/alti/views/profile.py
+++ b/alti/views/profile.py
@@ -50,13 +50,8 @@ class Profile(ProfileValidation):
     def _compute_points(self):
         """Compute the alt=fct(dist) array and store it in c.points"""
         rasters = [get_raster(layer, self.sr) for layer in self.layers]
-        # Simplify input line with a tolerance of 2 m
-        if self.nb_points < len(self.linestring.coords):
-            linestring = self.linestring.simplify(12.5)
-        else:
-            linestring = self.linestring
 
-        coords = self._create_points(linestring.coords, self.nb_points)
+        coords = self._create_points(self.linestring.coords, self.nb_points)
         zvalues = {}
         for i in xrange(0, len(self.layers)):
             zvalues[self.layers[i]] = []


### PR DESCRIPTION
This PR makes the service usable, i.e. the user may get the altitude of all given point in the input line, without fancy simplification, smoothing or points densification.
You have to give params `offset=0` and `nb_points` the exact number of coordinates in the input line. No smoothing per default.

```
A 10 km lines with three points 5km apart:
 curl -H <..snip...> -sg 'http://service-alti.int.bgdi.ch/mom_opti/rest/services/profile.json?nb_points=3&offset=0&geom={%22type%22%3A%22LineString%22%2C%22coordinates%22%3A[[2600000%2C1200000]%2C[2600000%2C1205000]%2C[2600000%2C1210000]]}' | jq '.'
[
  {
    "dist": 0,
    "alts": {
      "DTM25": 560.2
    },
    "easting": 2600000,
    "northing": 1200000
  },
  {
    "dist": 5000,
    "alts": {
      "DTM25": 552
    },
    "easting": 2600000,
    "northing": 1205000
  },
  {
    "dist": 10000,
    "alts": {
      "DTM25": 580.2
    },
    "easting": 2600000,
    "northing": 1210000
  }
]
``` 

[Test link in geoadmin offset =0](https://map.geo.admin.ch/?alti_url=%2F%2Fservice-alti.int.bgdi.ch%2Fmom_opti%2F&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,KML%7C%7Chttps:%2F%2Fpublic.geo.admin.ch%2FJ2wBbtQnQuWYk2GRQEpuhw&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,)
[https://service-alti.int.bgdi.ch/mom_opti](https://service-alti.int.bgdi.ch/mom_opti)