### PR TITLE
Support for WebMerc and WGS1984

### DIFF
--- a/alti/__init__.py
+++ b/alti/__init__.py
@@ -6,6 +6,9 @@ from pyramid.renderers import JSONP
 from alti.renderers import CSVRenderer
 from alti.lib.raster.georaster import init_rasterfiles
 
+SUPPORTED_SRS = (21781, 2056, 3857, 4326)
+NATIVE_SRS = 2056
+
 
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.

--- a/alti/lib/helpers.py
+++ b/alti/lib/helpers.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import math
+from functools import partial
+from shapely.ops import transform as shape_transform
+from pyproj import Proj, transform as proj_transform
 
 
 # float('NaN') does not raise an Exception. This function does.
@@ -15,3 +18,25 @@ def filter_alt(alt):
     if alt is not None and alt > 0.0:
         # 10cm accuracy is enough for altitudes
         return round(alt, 1)
+
+
+def get_proj_from_srid(srid):
+    return Proj(init='EPSG:{}'.format(srid))
+
+
+def transform_coordinate(coords, srid_from, srid_to):
+    proj_in = get_proj_from_srid(srid_from)
+    proj_out = get_proj_from_srid(srid_to)
+    return proj_transform(proj_in, proj_out, coords[0], coords[1])
+
+
+def transform_shape(geom, srid_from, srid_to):
+    if (srid_from == srid_to):
+        return geom
+
+    proj_in = get_proj_from_srid(srid_from)
+    proj_out = get_proj_from_srid(srid_to)
+
+    projection_func = partial(proj_transform, proj_in, proj_out)
+
+    return shape_transform(projection_func, geom)

--- a/alti/lib/validation/__init__.py
+++ b/alti/lib/validation/__init__.py
@@ -1,13 +1,26 @@
 # -*- coding: utf-8 -*-
 
 
-from shapely.geometry import Polygon
+from shapely.geometry import box
 
 
-bboxes = {
+extents = {
     2056: (2450000, 1030000, 2900000, 1350000),
-    21781: (450000, 30000, 900000, 350000)
+    21781: (450000, 30000, 900000, 350000),
+    3857: (603111.3901608731, 5677741.733673414, 1277662.4228336029, 6154011.090045582),
+    4326: (5.41784179808085, 45.35600083019525, 11.477436823766046, 48.28267323232726)
+
 }
+
+
+def init_bboxes():
+    bboxes = {}
+    for epsg, bbox in extents.iteritems():
+        dtm_poly = box(*bbox)
+        bboxes[epsg] = dtm_poly
+    return bboxes
+
+bboxes = init_bboxes()
 
 
 def srs_guesser(geom):
@@ -19,8 +32,7 @@ def srs_guesser(geom):
 
     if geom_type in ('Point', 'LineString'):
         for epsg, bbox in bboxes.iteritems():
-            dtm_poly = Polygon([(bbox[0], bbox[1]), (bbox[2], bbox[1]), (bbox[2], bbox[3]), (bbox[0], bbox[3])])
-            if dtm_poly.contains(geom):
+            if bbox.contains(geom):
                 sr = epsg
                 break
     return sr

--- a/alti/lib/validation/__init__.py
+++ b/alti/lib/validation/__init__.py
@@ -23,16 +23,18 @@ def init_bboxes():
 bboxes = init_bboxes()
 
 
-def srs_guesser(geom):
-    sr = None
-    try:
-        geom_type = geom.geom_type
-    except ValueError:
-        return sr
+class SrsValidation(object):
 
-    if geom_type in ('Point', 'LineString'):
-        for epsg, bbox in bboxes.iteritems():
-            if bbox.contains(geom):
-                sr = epsg
-                break
-    return sr
+    def srs_guesser(self, geom):
+        sr = None
+        try:
+            geom_type = geom.geom_type
+        except ValueError:
+            return sr
+
+        if geom_type in ('Point', 'LineString'):
+            for epsg, bbox in bboxes.iteritems():
+                if bbox.contains(geom):
+                    sr = epsg
+                    break
+        return sr

--- a/alti/lib/validation/height.py
+++ b/alti/lib/validation/height.py
@@ -3,11 +3,10 @@
 from pyramid.httpexceptions import HTTPBadRequest
 
 from alti.lib.helpers import float_raise_nan
+from alti.lib.validation import SrsValidation
 
-SUPPORTED_SRS = (21781, 2056, 3857, 4326)
 
-
-class HeightValidation(object):
+class HeightValidation(SrsValidation):
 
     def __init__(self):
         self._lon = None
@@ -60,6 +59,6 @@ class HeightValidation(object):
 
     @sr.setter
     def sr(self, value):
-        if value not in (21781, 2056, 3857, 4326):
-            raise HTTPBadRequest("Please provide a valid number for the spatial reference system model ({})".format(SUPPORTED_SRS))
+        if value not in self.supported_srs:
+            raise HTTPBadRequest("Please provide a valid number for the spatial reference system model ({})".format(self.supported_srs))
         self._sr = value

--- a/alti/lib/validation/height.py
+++ b/alti/lib/validation/height.py
@@ -4,6 +4,8 @@ from pyramid.httpexceptions import HTTPBadRequest
 
 from alti.lib.helpers import float_raise_nan
 
+SUPPORTED_SRS = (21781, 2056, 3857, 4326)
+
 
 class HeightValidation(object):
 
@@ -58,6 +60,6 @@ class HeightValidation(object):
 
     @sr.setter
     def sr(self, value):
-        if value not in (21781, 2056):
-            raise HTTPBadRequest("Please provide a valid number for the spatial reference system model 21781 or 2056")
+        if value not in (21781, 2056, 3857, 4326):
+            raise HTTPBadRequest("Please provide a valid number for the spatial reference system model ({})".format(SUPPORTED_SRS))
         self._sr = value

--- a/alti/tests/functional/test_helpers.py
+++ b/alti/tests/functional/test_helpers.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from shapely.geometry import Point
-from alti.lib.helpers import float_raise_nan, filter_alt
-from alti.lib.validation import srs_guesser
+import pyproj
+from shapely.geometry import Point, box
+from alti.lib.helpers import float_raise_nan, filter_alt, get_proj_from_srid, transform_coordinate, transform_shape
+from alti.lib.validation import SrsValidation
 
 
 class Test_Helpers(unittest.TestCase):
@@ -26,8 +27,36 @@ class Test_Helpers(unittest.TestCase):
         self.assertEqual(100.1, filter_alt(alt))
 
     def test_srs_guesser(self):
-        self.assertEqual(srs_guesser(Point(7, 46)), 4326)
-        self.assertEqual(srs_guesser(Point(600000, 200000)), 21781)
-        self.assertEqual(srs_guesser(Point(2600000, 1200000)), 2056)
-        self.assertEqual(srs_guesser(Point(800000, 5900000)), 3857)
-        self.assertEqual(srs_guesser(Point(2, 2)), None)
+        validator = SrsValidation()
+        self.assertEqual(validator.srs_guesser(Point(7, 46)), 4326)
+        self.assertEqual(validator.srs_guesser(Point(600000, 200000)), 21781)
+        self.assertEqual(validator.srs_guesser(Point(2600000, 1200000)), 2056)
+        self.assertEqual(validator.srs_guesser(Point(800000, 5900000)), 3857)
+        self.assertEqual(validator.srs_guesser(Point(2, 2)), None)
+
+    def test_get_proj(self):
+        self.assertIsInstance(get_proj_from_srid(21781), pyproj.Proj)
+
+    def test_transform_coordinate(self):
+        lv03 = (600000, 200000)
+        lv95 = transform_coordinate(lv03, 21781, 2056)
+        wgs84 = transform_coordinate(lv03, 21781, 4326)
+        self.assertLess(abs(lv95[0] - 2600000.0), 0.1)
+        self.assertLess(abs(lv95[1] - 1200000.0), 0.1)
+        self.assertLess(abs(wgs84[0] - 7.438632495), 0.000001)
+        self.assertLess(abs(wgs84[1] - 46.951082877), 0.000001)
+
+    def test_transform_shape(self):
+        coords = (2450000, 1030000, 2900000, 1350000)
+        box_lv95 = box(*coords)
+        bounds_merc = transform_shape(box_lv95, 2056, 3857).bounds
+        self.assertLess(abs(bounds_merc[0] - 603111.39), 0.1)
+        self.assertLess(abs(bounds_merc[1] - 5677741.73), 0.1)
+        self.assertLess(abs(bounds_merc[2] - 1277662.42), 0.1)
+        self.assertLess(abs(bounds_merc[3] - 6154011.09), 0.1)
+
+    def test_no_transform_shape(self):
+        coords = (2450000, 1030000, 2900000, 1350000)
+        box_lv95 = box(*coords)
+        bounds  = transform_shape(box_lv95, 2056, 2056).bounds
+        self.assertLess(abs(bounds[0] - 2450000.0), 0.0000001)

--- a/alti/tests/functional/test_helpers.py
+++ b/alti/tests/functional/test_helpers.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+from shapely.geometry import Point
 from alti.lib.helpers import float_raise_nan, filter_alt
+from alti.lib.validation import srs_guesser
 
 
 class Test_Helpers(unittest.TestCase):
@@ -22,3 +24,10 @@ class Test_Helpers(unittest.TestCase):
         self.assertEqual(alt, filter_alt(alt))
         alt = 100.111
         self.assertEqual(100.1, filter_alt(alt))
+
+    def test_srs_guesser(self):
+        self.assertEqual(srs_guesser(Point(7, 46)), 4326)
+        self.assertEqual(srs_guesser(Point(600000, 200000)), 21781)
+        self.assertEqual(srs_guesser(Point(2600000, 1200000)), 2056)
+        self.assertEqual(srs_guesser(Point(800000, 5900000)), 3857)
+        self.assertEqual(srs_guesser(Point(2, 2)), None)

--- a/alti/tests/integration/test_height.py
+++ b/alti/tests/integration/test_height.py
@@ -105,3 +105,14 @@ class TestHeightView(TestsBase):
     def test_height_lv03_miss_easting(self):
         resp = self.testapp.get('/rest/services/height', params={'northing': '200000'}, headers=self.headers, status=400)
         resp.mustcontain("Missing parameter 'easting'/'lon'")
+
+    def test_different_srs_return_same_height(self):
+        # Summit of Finsteraarhorn
+        resp_lv03 = self.testapp.get('/rest/services/height', params={'easting': '652741.57', 'northing': '154231.64', 'layers': 'DTM2'}, headers=self.headers, status=200)
+        resp_lv95 = self.testapp.get('/rest/services/height', params={'easting': '2652741.5', 'northing': '1154231.4', 'layers': 'DTM2'}, headers=self.headers, status=200)
+        resp_wgs84 = self.testapp.get('/rest/services/height', params={'easting': '8.12617', 'northing': '46.53730', 'layers': 'DTM2'}, headers=self.headers, status=200)
+
+        height = resp_lv95.json['height']
+
+        self.assertEqual(resp_lv03.json['height'], height)
+        self.assertEqual(resp_wgs84.json['height'], height)

--- a/alti/tests/integration/test_height.py
+++ b/alti/tests/integration/test_height.py
@@ -18,7 +18,7 @@ class TestHeightView(TestsBase):
         self.assertEqual(resp.json['height'], '560.2')
 
     def test_height_no_sr_using_wrong_coordinates(self):
-        self.testapp.get('/rest/services/height', params={'easting': '7.66', 'northing': '46.7'}, headers=self.headers, status=400)
+        self.testapp.get('/rest/services/height', params={'easting': '102', 'northing': '-46.7'}, headers=self.headers, status=400)
 
     def test_height_using_unknown_sr(self):
         self.testapp.get('/rest/services/height', params={'easting': '600000.1', 'northing': '200000.1', 'sr': 666}, headers=self.headers, status=400)
@@ -111,8 +111,10 @@ class TestHeightView(TestsBase):
         resp_lv03 = self.testapp.get('/rest/services/height', params={'easting': '652741.57', 'northing': '154231.64', 'layers': 'DTM2'}, headers=self.headers, status=200)
         resp_lv95 = self.testapp.get('/rest/services/height', params={'easting': '2652741.5', 'northing': '1154231.4', 'layers': 'DTM2'}, headers=self.headers, status=200)
         resp_wgs84 = self.testapp.get('/rest/services/height', params={'easting': '8.12617', 'northing': '46.53730', 'layers': 'DTM2'}, headers=self.headers, status=200)
+        resp_webmerc = self.testapp.get('/rest/services/height', params={'easting': '904601.0976097584', 'northing': '5866874.330271561', 'layers': 'DTM2'}, headers=self.headers, status=200)
 
         height = resp_lv95.json['height']
 
         self.assertEqual(resp_lv03.json['height'], height)
         self.assertEqual(resp_wgs84.json['height'], height)
+        self.assertEqual(resp_webmerc.json['height'], height)

--- a/alti/tests/integration/test_profile.py
+++ b/alti/tests/integration/test_profile.py
@@ -38,7 +38,7 @@ class TestProfileView(TestsBase):
 
     def test_profile_invalide_sr_json_valid(self):
         resp = self.testapp.get('/rest/services/profile.json', params={'sr': 666, 'geom': create_json(3, 21781)}, headers=self.headers, status=400)
-        resp.mustcontain("Please provide a valid number for the spatial reference system model 21781 or 2056")
+        resp.mustcontain("Please provide a valid number for the spatial reference system model")
 
     def test_profile_lv95_json_valid(self):
         self.testapp.get('/rest/services/profile.json', params={'sr': 2056, 'geom': create_json(4, 2056)}, headers=self.headers, status=200)

--- a/alti/views/height.py
+++ b/alti/views/height.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
 
 from shapely.geometry import Point
-from alti.lib.helpers import filter_alt
+from alti.lib.helpers import filter_alt, transform_coordinate
 from alti.lib.validation import srs_guesser
 from alti.lib.validation.height import HeightValidation
 from alti.lib.raster.georaster import get_raster
 
 from pyramid.view import view_config
 from pyramid.httpexceptions import HTTPBadRequest
+
+
+SUPPORTED_SRS = (21781, 2056, 3857, 4326)
+NATIVE_SRS = 2056
 
 
 class Height(HeightValidation):
@@ -37,12 +41,17 @@ class Height(HeightValidation):
                 raise HTTPBadRequest("No 'sr' given and cannot be guessed from 'geom'")
             else:
                 self.sr = sr
+        if self.sr not in (2056, 21781):
+            self.lon, self.lat = transform_coordinate((self.lon, self.lat), self.sr, NATIVE_SRS)
+            self.sr_in = NATIVE_SRS
+        else:
+            self.sr_in = self.sr
 
         self.request = request
 
     @view_config(route_name='height', renderer='jsonp', http_cache=0)
     def height(self):
-        rasters = [get_raster(layer, self.sr) for layer in self.layers]
+        rasters = [get_raster(layer, self.sr_in) for layer in self.layers]
         alt = filter_alt(rasters[0].getVal(self.lon, self.lat))
         if alt is None:
             raise HTTPBadRequest('Requested coordinate ({},{}) out of bounds in sr {}'.format(self.lon, self.lat, self.sr))

--- a/alti/views/height.py
+++ b/alti/views/height.py
@@ -16,7 +16,7 @@ class Height(HeightValidation):
         super(Height, self).__init__()
         self.native_srs = int(request.registry.settings.get('native_srs', 2056))
         supported_srs = request.registry.settings.get('supported_srs', '2056,21781')
-        self.supported_srs = map(int,supported_srs.split(','))
+        self.supported_srs = map(int, supported_srs.split(','))
 
         if 'easting' in request.params:
             self.lon = request.params.get('easting')

--- a/alti/views/profile.py
+++ b/alti/views/profile.py
@@ -19,7 +19,7 @@ class Profile(ProfileValidation):
         self.nb_points_max = int(request.registry.settings.get('profile_nb_points_maximum', 500))
         self.native_srs = int(request.registry.settings.get('native_srs', 2056))
         supported_srs = request.registry.settings.get('supported_srs', '2056,21781')
-        self.supported_srs = map(int,supported_srs.split(','))
+        self.supported_srs = map(int, supported_srs.split(','))
 
         self.linestring = request.params.get('geom')
 

--- a/production.ini.in
+++ b/production.ini.in
@@ -29,6 +29,8 @@ http_proxy = ${http_proxy}
 
 profile_nb_points_default = 200
 profile_nb_points_maximum = 500
+native_srs = 2056
+supported_srs = 2056,21781,3857,4326
 
 ###
 # wsgi server configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ geojson==1.3.4
 Mako==1.0.0
 nose==1.3.7
 pycodestyle==2.0.0
+pyproj==1.9.5.1
 pyramid==1.8.3
 pyramid-debugtoolbar==3.0.2
 regex==2014.2.19


### PR DESCRIPTION
Reprojection via `pyproj`, so not very efficient.

TODO: Distance along profile, especially in WGS1984 (ellispoidal distance or what?)


some link for testing (Referer check)

### Finsteraarhorn

**EPSG:3857**
http://mf-chsdi3.dev.bgdi.ch/webmerc/rest/services/height?easting=904601.0976097584&northing=5866874.330271561

**EPSG:4326**
http://mf-chsdi3.dev.bgdi.ch/webmerc/rest/services/height?easting=8.12617&northing=46.53730

**EPSG:2056**
http://mf-chsdi3.dev.bgdi.ch/webmerc/rest/services/height?easting=2652741.5&northing=1154231.4

### Profile

**EPSG:21781**
http://mf-chsdi3.dev.bgdi.ch/webmerc/rest/services/profile.json?geom=%7B%22type%22%3A+%22LineString%22%2C+%22coordinates%22%3A+%5B%5B2550050.0%2C+1206549.999999998%5D%2C+%5B2556950.0%2C+1204149.9999999981%5D%2C+%5B2561050.0%2C+1207949.9999999993%5D%5D%7D

**EPSG:4326**
http://mf-chsdi3.dev.bgdi.ch/webmerc/rest/services/profile.json?geom=%7B%22type%22%3A+%22LineString%22%2C+%22coordinates%22%3A+%5B%5B6.781776765688703%2C+47.008113247252105%5D%2C+%5B6.8727381951864945%2C+46.987010403135706%5D%2C+%5B6.926304191523524%2C+47.02144494590933%5D%5D%7D

**EPSG:3857**
http://mf-chsdi3.dev.bgdi.ch/webmerc/rest/services/profile.json?geom=%7B%22type%22%3A+%22LineString%22%2C+%22coordinates%22%3A+%5B%5B754943.9362301202%2C+5943398.461445041%5D%2C+%5B765069.7162436416%2C+5939954.097281152%5D%2C+%5B771032.6556797158%2C+5945575.136169084%5D%5D%7D

See https://github.com/geoadmin/mf-chsdi3/pull/3030

See https://github.com/geoadmin/service-alti/issues/39
