### PR TITLE
Accept geom in HTTP POST body

### DIFF
--- a/alti/lib/validation/profile.py
+++ b/alti/lib/validation/profile.py
@@ -56,7 +56,7 @@ class ProfileValidation(object):
 
     @linestring.setter
     def linestring(self, value):
-        if value is None:
+        if value is None or value == '':
             raise HTTPBadRequest("Missing parameter geom")
         try:
             geom = geojson.loads(value, object_hook=geojson.GeoJSON.to_instance)

--- a/alti/views/profile.py
+++ b/alti/views/profile.py
@@ -16,7 +16,10 @@ class Profile(ProfileValidation):
         super(Profile, self).__init__()
         self.nb_points_default = int(request.registry.settings.get('profile_nb_points_default', 200))
         self.nb_points_max = int(request.registry.settings.get('profile_nb_points_maximum', 500))
-        self.linestring = request.params.get('geom')
+        if 'geom' in request:
+            self.linestring = request.params.get('geom')
+        else:
+            self.linestring = request.body
         if 'layers' in request.params:
             self.layers = request.params.get('layers')
         else:

--- a/alti/views/profile.py
+++ b/alti/views/profile.py
@@ -16,7 +16,7 @@ class Profile(ProfileValidation):
         super(Profile, self).__init__()
         self.nb_points_default = int(request.registry.settings.get('profile_nb_points_default', 200))
         self.nb_points_max = int(request.registry.settings.get('profile_nb_points_maximum', 500))
-        if 'geom' in request:
+        if 'geom' in request.params:
             self.linestring = request.params.get('geom')
         else:
             self.linestring = request.body

--- a/deploy/deploy-branch.cfg.in
+++ b/deploy/deploy-branch.cfg.in
@@ -20,10 +20,8 @@ content = Include /var/www/vhosts/service-alti/private/branch/${git_branch}/apac
 
 [remote_hosts]
 # mf0i
-int = ip-10-220-6-105.eu-west-1.compute.internal,
-      ip-10-220-6-208.eu-west-1.compute.internal
+int = ip-10-220-4-219.eu-west-1.compute.internal,
+      ip-10-220-5-117.eu-west-1.compute.internal
 
-# demo
-demo = ip-10-220-5-174.eu-west-1.compute.internal
 # NO PROD FOR BRANCH
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ autopep8==1.2.4
 coverage==4.1
 flake8==3.0.4
 geojson==1.3.4
-Mako==1.0.0
+Mako==1.1.0
 nose==1.3.7
 pycodestyle==2.0.0
 pyramid==1.10.1


### PR DESCRIPTION
To be able to checkout perf improvement with https://github.com/geoadmin/service-alti/pull/46
I need to be able to send Wanderweg profile (around 2000 points). With actual master it's not possible as this exceed URL max length when writing down this kind of GeoJSON into the URL.

In order to circumvent this, this PR make the profile service check the body of the HTTP request if no `geom` param is found in the URL.