### PR TITLE
Rollback changes made on profile JSON structure

### DIFF
--- a/alti/lib/profile_helpers.py
+++ b/alti/lib/profile_helpers.py
@@ -61,7 +61,11 @@ def _create_profile(coordinates, z_values, output_to_json):
             rounded_dist = filter_distance(total_distance)
             if output_to_json:
                 profile.append({
-                    'alts': alt,
+                    'alts': {
+                        'COMB': alt,
+                        'DTM2': alt,
+                        'DTM25': alt
+                    },
                     'dist': rounded_dist,
                     'easting': filter_coordinate(coordinates[j][0]),
                     'northing': filter_coordinate(coordinates[j][1])

--- a/alti/tests/functional/test_profile_helpers.py
+++ b/alti/tests/functional/test_profile_helpers.py
@@ -51,7 +51,7 @@ class TestProfileHelpers(unittest.TestCase):
         # i           : 0 .... 19 20 .... 39 40 .... etc ... 198 199 (exception with the last point)
         # value index : 0 .... 0   1 .... 1   2 .... etc ...  9   10
         for i in range(len(response)):
-            value = response[i]['alts']
+            value = response[i]['alts']['COMB']
             value_index = 10 if i == 199 else i / 20
             expected_value = round(VALUES_FOR_EACH_2M_STEP[value_index] * 10.0) / 10.0
             self.assertEqual(value,
@@ -70,7 +70,7 @@ class TestProfileHelpers(unittest.TestCase):
         # each values should be present only once, so we can test them in sequence (with the exception of rounding,
         # the value at index 9 should be rounded to the first digit : 123.456 => 123.5)
         for i in range(len(response)):
-            value = response[i]['alts']
+            value = response[i]['alts']['COMB']
             expected = round(VALUES_FOR_EACH_2M_STEP[i] * 10.0) / 10.0
             self.assertEqual(value,
                              expected,

--- a/alti/tests/integration/test_profile.py
+++ b/alti/tests/integration/test_profile.py
@@ -100,12 +100,12 @@ class TestProfileView(TestsBase):
         self.assertEqual(resp.content_type, 'application/json')
         first_point = resp.json[0]
         self.assertEqual(first_point['dist'], 0)
-        self.assertEqual(first_point['alts'], 567.3)
+        self.assertEqual(first_point['alts']['COMB'], 567.3)
         self.assertEqual(first_point['easting'], 630000)
         self.assertEqual(first_point['northing'], 170000)
         second_point = resp.json[1]
         self.assertEqual(second_point['dist'], 40)
-        self.assertEqual(second_point['alts'], 568.5)
+        self.assertEqual(second_point['alts']['COMB'], 568.5)
         self.assertEqual(second_point['easting'], 630032.0)
         self.assertEqual(second_point['northing'], 170024.0)
         self.__verify_point_is_present(resp, POINT_1_LV03)
@@ -278,3 +278,18 @@ class TestProfileView(TestsBase):
         self.__verify_point_is_present(resp, point5, msg="point5 not present")
         self.__verify_point_is_present(resp, point6, msg="point6 not present")
         self.__verify_point_is_present(resp, point7, msg="point7 not present")
+
+    def test_profile_all_old_elevation_models_are_returned(self):
+        resp = self.__get_json_profile(params={'geom': LINESTRING_VALID_LV95},
+                                       expected_status=200)
+        self.assertTrue(resp.content_type == 'application/json')
+        altitudes = resp.json[0]['alts']
+        comb_value = altitudes['COMB']
+        self.assertIsNotNone(altitudes.get('DTM2'),
+                             msg="All old elevation_models must be returned in alt for compatibility issue")
+        self.assertEqual(altitudes['DTM2'], comb_value,
+                         msg="All values from all models should be taken from the new COMB layer")
+        self.assertIsNotNone(altitudes.get('DTM25'),
+                             msg="All old elevation_models must be returned in alt for compatibility issue")
+        self.assertEqual(altitudes['DTM25'], comb_value,
+                         msg="All values from all models should be taken from the new COMB layer")


### PR DESCRIPTION
Always return the "old" JSON structure, but filling the now empty elevation_models with the new COMB values.
```
{
   ...
   'alts': {
      'COMB': ...,
      'DTM2': ...,
      'DTM25': ...
   }
   ...
}
```