### PR TITLE
Removing deleted methods usage

### DIFF
--- a/alti/lib/profile_helpers.py
+++ b/alti/lib/profile_helpers.py
@@ -197,9 +197,6 @@ def _extract_z_values(raster, coordinates):
                 tiles.append(tile)
                 z = tile.get_height_for_coordinate(x, y)
         z_values.append(z)
-    # at the end we close all tile files
-    for tile in tiles:
-        tile.close_file()
     return z_values
 
 


### PR DESCRIPTION
As we don't have (yet) a CI that can run integration tests (I also forgot to run them before merging https://github.com/geoadmin/service-alti/pull/66 ) here is a little fix for what popped up during integration test