### PR TITLE
support for python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,36 @@ RED := $(shell tput setaf 1)
 GREEN := $(shell tput setaf 2)
 
 # Versions
-PYTHON_VERSION := $(shell python --version 2>&1 | cut -d ' ' -f 2 | cut -d '.' -f 1,2)
+ifndef USE_PYTHON3
+		override USE_PYTHON3 = 0
+endif
+
+ifeq ($(USE_PYTHON3), 1)
+		PYTHON_VERSION := 3.8.3
+build/python: local/bin/python3.8
+		mkdir -p build && touch build/python;
+else
+		PYTHON_VERSION := $(shell python2 --version 2>&1 | cut -d ' ' -f 2 | cut -d '.' -f 1,2)
+build/python:
+		mkdir -p build && touch build/python;
+endif
 PYTHONPATH ?= .venv/lib/python${PYTHON_VERSION}/site-packages:/usr/lib64/python${PYTHON_VERSION}/site-packages
+
+
+PYTHON_BINDIR := $(shell dirname $(PYTHON_CMD))
+PYTHONHOME :=$(shell eval "cd $(PYTHON_BINDIR); pwd; cd > /dev/null")
+SYSTEM_PYTHON_CMD := $(CURRENT_DIR)/local/bin/python3
+
+.PHONY: python
+python: build/python
+		@echo "Python installed"
+
+local/bin/python3.8:
+		mkdir -p $(CURRENT_DIRECTORY)/local;
+		curl -z $(CURRENT_DIRECTORY)/local/Python-$(PYTHON_VERSION).tar.xz \
+				https://www.python.org/ftp/python/$(PYTHON_VERSION)/Python-$(PYTHON_VERSION).tar.xz \
+				-o $(CURRENT_DIRECTORY)/local/Python-$(PYTHON_VERSION).tar.xz;
+		cd $(CURRENT_DIRECTORY)/local && tar -xf Python-$(PYTHON_VERSION).tar.xz && Python-$(PYTHON_VERSION)/configure
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ help:
 	@echo
 	@echo "Possible targets:"
 	@echo "- user               Build the user specific version of the app"
-	@echo "- all                Build the app"
+	@echo "- all                Build the app. Set USE_PYTHON3 to 1 to build with Python 3"
 	@echo "- serve              Serve the application with pserve"
 	@echo "- shell              Enter interactive shell with app loaded in the background"
 	@echo "- test               Launch the tests (no e2e tests)"
@@ -111,6 +111,7 @@ help:
 	@echo "BRANCH_STAGING:      ${BRANCH_STAGING}"
 	@echo "GIT_BRANCH:          ${GIT_BRANCH}"
 	@echo "SERVER_PORT:         ${SERVER_PORT}"
+	@echo "USE_PYTHON3:         ${USE_PYTHON3}"
 	@echo
 
 

--- a/alti/lib/profile_helpers.py
+++ b/alti/lib/profile_helpers.py
@@ -3,7 +3,9 @@ from shapely.geometry import LineString
 
 from alti.lib.raster.georaster import get_raster, RESOLUTION
 from alti.lib.helpers import filter_coordinate, filter_distance, filter_altitude
-
+# TODO: remove dual version support. Here: change xrange to range within the code
+if six.PY3:
+    xrange = range
 PROFILE_MAX_AMOUNT_POINTS = 5000
 PROFILE_DEFAULT_AMOUNT_POINTS = 200
 

--- a/alti/lib/profile_helpers.py
+++ b/alti/lib/profile_helpers.py
@@ -1,4 +1,6 @@
 import math
+import six
+
 from shapely.geometry import LineString
 
 from alti.lib.raster.georaster import get_raster, RESOLUTION

--- a/alti/lib/raster/dbfutils.py
+++ b/alti/lib/raster/dbfutils.py
@@ -6,6 +6,10 @@ import struct
 import datetime
 import decimal
 import itertools
+import six
+# TODO: remove dual version support. Here: change xrange to range within the code
+if six.PY3:
+    xrange = range
 
 
 def dbfreader(f):

--- a/alti/renderers.py
+++ b/alti/renderers.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+import six
+import csv
+
+if six.PY2:
+    from StringIO import StringIO
+else:
+    from io import StringIO
 
 
 class CSVRenderer(object):
@@ -7,9 +14,7 @@ class CSVRenderer(object):
         pass
 
     def __call__(self, value, system):
-        import csv
-        import StringIO
-        fout = StringIO.StringIO()
+        fout = StringIO()
         writer = csv.writer(fout, delimiter=';', quoting=csv.QUOTE_ALL)
 
         writer.writerow(value['headers'])

--- a/alti/tests/integration/test_profile.py
+++ b/alti/tests/integration/test_profile.py
@@ -6,6 +6,9 @@ from shapely.geometry import Point, LineString, mapping
 from mock import Mock, patch
 from alti.tests.integration import TestsBase
 from alti.lib.profile_helpers import PROFILE_MAX_AMOUNT_POINTS, PROFILE_DEFAULT_AMOUNT_POINTS
+# TODO: remove dual version support. Here: change xrange to range within the code
+if six.PY3:
+    xrange = range
 
 
 def generate_random_coord(srid):

--- a/alti/tests/integration/test_profile.py
+++ b/alti/tests/integration/test_profile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import six
 import json
 import random
 from shapely.geometry import Point, LineString, mapping


### PR DESCRIPTION
I kept xrange in the code rather than already switchint to range (which is also supported in python2), because performance-wise, xrange is better in python2 than range (the comportment of range in python3 has been altered to be the same as xrange). This is ugly, but should be temporary.

I also put little TODOS to explain what is left to do to finish the transition. It's not much.