### PR TITLE
BGDIINF_SB-1260: Use UTC time format in logging

### DIFF
--- a/logging-cfg-dev.yml
+++ b/logging-cfg-dev.yml
@@ -26,7 +26,8 @@ filters:
     application: service-alti
   isotime:
     (): logging_utilities.filters.TimeAttribute
-    isotime: True
+    isotime: False
+    utc_isotime: True
   flask:
     (): logging_utilities.filters.flask_attribute.FlaskRequestAttribute
     attributes:
@@ -46,7 +47,7 @@ formatters:
     add_always_extra: True
     filter_attributes:
       - application
-      - isotime
+      - utc_isotime
       - flask_request_url
       - flask_request_method
       - flask_request_headers
@@ -54,7 +55,7 @@ formatters:
       - flask_request_remote_addr
     remove_empty: True
     fmt:
-      time: isotime
+      time: utc_isotime
       level: levelname
       app: application
       logger: name

--- a/logging-cfg-local.yml
+++ b/logging-cfg-local.yml
@@ -26,7 +26,8 @@ filters:
     application: service-alti
   isotime:
     (): logging_utilities.filters.TimeAttribute
-    isotime: True
+    isotime: False
+    utc_isotime: True
   flask:
     (): logging_utilities.filters.flask_attribute.FlaskRequestAttribute
     attributes:
@@ -46,7 +47,7 @@ formatters:
     add_always_extra: True
     filter_attributes:
       - application
-      - isotime
+      - utc_isotime
       - flask_request_url
       - flask_request_method
       - flask_request_headers
@@ -54,7 +55,7 @@ formatters:
       - flask_request_remote_addr
     remove_empty: True
     fmt:
-      time: isotime
+      time: utc_isotime
       level: levelname
       app: application
       logger: name

--- a/logging-cfg-prod.yml
+++ b/logging-cfg-prod.yml
@@ -26,7 +26,8 @@ filters:
     application: service-alti
   isotime:
     (): logging_utilities.filters.TimeAttribute
-    isotime: True
+    isotime: False
+    utc_isotime: True
   flask:
     (): logging_utilities.filters.flask_attribute.FlaskRequestAttribute
     attributes:
@@ -46,7 +47,7 @@ formatters:
     add_always_extra: True
     filter_attributes:
       - application
-      - isotime
+      - utc_isotime
       - flask_request_url
       - flask_request_method
       - flask_request_headers
@@ -54,7 +55,7 @@ formatters:
       - flask_request_remote_addr
     remove_empty: True
     fmt:
-      time: isotime
+      time: utc_isotime
       level: levelname
       app: application
       logger: name


### PR DESCRIPTION

UTC time format is a better choice for the ELK (Elastic Logstash
Kibana).

See https://jira.swisstopo.ch/browse/BGDIINF_SB-1260