### PR TITLE
BGDIINF_SB-1808: Fixed pylint false positive and FD leak

### DIFF
--- a/app/helpers/raster/shputils.py
+++ b/app/helpers/raster/shputils.py
@@ -95,23 +95,22 @@ class SHPUtils(object):
         records = []
         # open dbf file and get records as a list
         dbf_file = file_name[0:-4] + '.dbf'
-        dbf = open(dbf_file, 'rb')
-        self.db = list(dbfutils.dbfreader(dbf))
-        dbf.close()
-        fp = open(file_name, 'rb')
+        with open(dbf_file, 'rb') as dbf:
+            self.db = list(dbfutils.dbfreader(dbf))
 
-        # get basic shapefile configuration
-        fp.seek(32)
-        read_and_unpack('i', fp.read(4))
-        read_bounding_box(fp)
+        with open(file_name, 'rb') as fp:
+            # get basic shapefile configuration
+            fp.seek(32)
+            read_and_unpack('i', fp.read(4))
+            read_bounding_box(fp)
 
-        # fetch Records
-        fp.seek(100)
-        while True:
-            shp_record = self.create_record(fp)
-            if shp_record is False:
-                break
-            records.append(shp_record)
+            # fetch Records
+            fp.seek(100)
+            while True:
+                shp_record = self.create_record(fp)
+                if shp_record is False:
+                    break
+                records.append(shp_record)
 
         return records
 

--- a/app/statistics/statistics.py
+++ b/app/statistics/statistics.py
@@ -4,10 +4,10 @@ DATA_FOLDER = "/var/local/geodata/bund/swisstopo/swissalti3d/hikingtime_analysis
 
 
 def load_json(filename):
-    json_file = open(DATA_FOLDER + filename, "r")
-    if json_file is None:
-        raise IOError("No metadata file found")
-    json_data = json.load(json_file)
+    with open(DATA_FOLDER + filename, "r") as json_file:
+        if json_file is None:
+            raise IOError("No metadata file found")
+        json_data = json.load(json_file)
     if json_data is None:
         return IOError("Failed to load JSON")
     return json_data

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,7 @@
 mock==4.0.2
 nose2==0.9.2
 pip-chill==1.0.0
-pylint==2.5.3
+pylint==2.8.2
 pylint-flask==0.6
 virtualenv==20.0.30
 yapf==0.30.0

--- a/tests/unit_tests/test_profile.py
+++ b/tests/unit_tests/test_profile.py
@@ -45,6 +45,7 @@ class TestProfile(unittest.TestCase):
         self.__check_response(response, expected_status)
         return response
 
+    # pylint: disable=inconsistent-return-statements
     def get_json_profile(self, params, expected_status=200):
         # pylint: disable=broad-except
         try:
@@ -55,7 +56,7 @@ class TestProfile(unittest.TestCase):
             return response
         except Exception as e:
             logger.exception(e)
-            self.fail('Call to test_instance failed')
+            self.fail('Call to test_instance failed: %s' % (e))
 
     def get_csv_with_params(self, params):
         return self.test_instance.get(

--- a/wsgi.py
+++ b/wsgi.py
@@ -11,7 +11,7 @@ class StandaloneApplication(BaseApplication):  # pylint: disable=abstract-method
     def __init__(self, app, options=None):  # pylint: disable=redefined-outer-name
         self.options = options or {}
         self.application = app
-        super(StandaloneApplication, self).__init__()
+        super().__init__()
 
     def load_config(self):
         config = {


### PR DESCRIPTION
Due to a bug in pylint (see https://github.com/PyCQA/pylint/issues/2625)
some pylint false positive were reported which prevent PR to be merge (see #81).

```
app/helpers/profile_helpers.py:180:39: E1101: Instance of 'BaseGeometry' has no 'x' member; maybe 'xy'? (no-member)
```

This issue might also have been introduced by the silent update of astroid which pylint depends on. To avoid such sub-dependencies issue in future we should update the repo to use pipenv instead. This will be done in a next pr.

Updating pylint to the latest version seems to solve this issue. However it introduced other pylint suggestions.

With the upgrade of pylint 2 file descriptor leak has been found. They have been fixed using with statement. Other minor pylint issue has been fixed as well.