### PR TITLE
Improved crash logging

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -35,7 +35,7 @@ def handle_exception(e):
     # pass through HTTP errors
     if isinstance(e, HTTPException):
         return e
-    logger.error(str(e))
+    logger.exception('Unexpected exception: %s', e)
     return make_error_msg(500, "Internal server error, please consult logs")
 
 


### PR DESCRIPTION
When the application crashed, the log did not contains any back trace,
but only a stringification of the exception which can be very short and
unusefull. For example if a KeyError is raised, str(e) would return only
the name of the key that cause the exception, which such info it is
almost impossible to know what cause the exception.