### PR TITLE
BGDIINF_SB-2197: Returns 415 in case of wrong content-type

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -378,10 +378,10 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
-ignore-imports=no
+ignore-imports=yes
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=12
 
 
 [VARIABLES]

--- a/app/helpers/validation/profile.py
+++ b/app/helpers/validation/profile.py
@@ -5,6 +5,7 @@ import geojson
 from shapely.geometry import shape
 
 from flask import abort
+from flask import request
 
 from app.helpers.profile_helpers import PROFILE_DEFAULT_AMOUNT_POINTS
 from app.helpers.profile_helpers import PROFILE_MAX_AMOUNT_POINTS
@@ -14,16 +15,16 @@ logger = logging.getLogger(__name__)
 max_content_length = 32 * 1024 * 1024  # 32MB
 
 
-def read_linestring(request_object):
+def read_linestring():
     # param geom, list of coordinates defining the line on which we want a profile
     linestring = None
     geom = None
     geom_to_shape = None
-    if 'geom' in request_object.args:
-        linestring = request_object.args.get('geom')
-    elif request_object.is_json and request_object.content_length is not None and \
-            0 < request_object.content_length < max_content_length:
-        linestring = request_object.get_data(as_text=True)  # read as text
+    if 'geom' in request.args:
+        linestring = request.args.get('geom')
+    elif request.is_json and request.content_length is not None and \
+            0 < request.content_length < max_content_length:
+        linestring = request.get_data(as_text=True)  # read as text
     if not linestring:
         abort(400, "No 'geom' given, cannot create a profile without coordinates")
     try:
@@ -51,12 +52,12 @@ def read_linestring(request_object):
     return geom_to_shape
 
 
-def read_number_points(request_object):
+def read_number_points():
     # number of points wanted in the final profile.
-    if 'nbPoints' in request_object.args:
-        nb_points = request_object.args.get('nbPoints')
-    elif 'nb_points' in request_object.args:
-        nb_points = request_object.args.get('nb_points')
+    if 'nbPoints' in request.args:
+        nb_points = request.args.get('nbPoints')
+    elif 'nb_points' in request.args:
+        nb_points = request.args.get('nb_points')
     else:
         nb_points = PROFILE_DEFAULT_AMOUNT_POINTS
 
@@ -78,20 +79,20 @@ def read_number_points(request_object):
     return nb_points
 
 
-def read_is_custom_nb_points(request_object):
+def read_is_custom_nb_points():
     # number of points wanted in the final profile.
-    return 'nbPoints' in request_object.args or 'nb_points' in request_object.args
+    return 'nbPoints' in request.args or 'nb_points' in request.args
 
 
-def read_spatial_reference(request_object, linestring):
+def read_spatial_reference(linestring):
     # param sr (or projection, sr meaning spatial reference), which Swiss projection to use.
     # Possible values are expressed in int, so value for EPSG:2056 (LV95) is 2056
     # and value for EPSG:21781 (LV03) is 21781. If this param is not present, it will be guessed
     # from the coordinates present in the param geom
-    if 'sr' in request_object.args:
-        spatial_reference = int(request_object.args.get('sr'))
-    elif 'projection' in request_object.args:
-        spatial_reference = int(request_object.args.get('projection'))
+    if 'sr' in request.args:
+        spatial_reference = int(request.args.get('sr'))
+    elif 'projection' in request.args:
+        spatial_reference = int(request.args.get('projection'))
     else:
         sr = srs_guesser(linestring)
         if sr is None:
@@ -106,12 +107,12 @@ def read_spatial_reference(request_object, linestring):
     return spatial_reference
 
 
-def read_offset(request_object):
+def read_offset():
     # param offset, used for smoothing. define how many coordinates should be included
     # in the window used for smoothing. If value is zero smoothing is disabled.
     offset = 3
-    if 'offset' in request_object.args:
-        offset = request_object.args.get('offset')
+    if 'offset' in request.args:
+        offset = request.args.get('offset')
         if offset.isdigit():
             offset = int(offset)
         else:

--- a/app/helpers/validation/profile.py
+++ b/app/helpers/validation/profile.py
@@ -22,9 +22,12 @@ def read_linestring():
     geom_to_shape = None
     if 'geom' in request.args:
         linestring = request.args.get('geom')
-    elif request.is_json and request.content_length is not None and \
-            0 < request.content_length < max_content_length:
-        linestring = request.get_data(as_text=True)  # read as text
+    elif request.method == 'POST':
+        if not request.is_json:
+            abort(415)
+        if request.content_length and 0 < request.content_length < max_content_length:
+            linestring = request.get_data(as_text=True)  # read as text
+
     if not linestring:
         abort(400, "No 'geom' given, cannot create a profile without coordinates")
     try:

--- a/app/routes.py
+++ b/app/routes.py
@@ -40,7 +40,7 @@ def handle_exception(e):
     return make_error_msg(500, "Internal server error, please consult logs")
 
 
-@app.route('/checker', methods=['GET'])
+@app.route('/checker')
 def check():
     return make_response(jsonify({'success': True, 'message': 'OK', 'version': APP_VERSION}))
 
@@ -76,38 +76,38 @@ def height_route():
 
 @app.route('/profile.json', methods=['GET', 'POST'])
 def profile_json_route():
-    return __get_profile_from_helper(request, True)
+    return __get_profile_from_helper(True)
 
 
 @app.route('/profile.csv', methods=['GET', 'POST'])
 def profile_csv_route():
-    return __get_profile_from_helper(request, False)
+    return __get_profile_from_helper(False)
 
 
-def __get_profile_from_helper(request_object, output_to_json=True):
-    linestring = profile_arg_validation.read_linestring(request_object)
-    nb_points = profile_arg_validation.read_number_points(request_object)
-    is_custom_nb_points = profile_arg_validation.read_is_custom_nb_points(request_object)
-    spatial_reference = profile_arg_validation.read_spatial_reference(request_object, linestring)
-    offset = profile_arg_validation.read_offset(request_object)
+def __get_profile_from_helper(output_to_json=True):
+    linestring = profile_arg_validation.read_linestring()
+    nb_points = profile_arg_validation.read_number_points()
+    is_custom_nb_points = profile_arg_validation.read_is_custom_nb_points()
+    spatial_reference = profile_arg_validation.read_spatial_reference(linestring)
+    offset = profile_arg_validation.read_offset()
 
     # param only_requested_points, which is flag that when set to True will make
     # the profile with only the given points in geom (no filling points)
-    if 'only_requested_points' in request_object.args:
-        only_requested_points = bool(request_object.args.get('only_requested_points'))
+    if 'only_requested_points' in request.args:
+        only_requested_points = bool(request.args.get('only_requested_points'))
     else:
         only_requested_points = False
 
     # flag that define if filling has to be smart, aka to take resolution into account (so that
     # there's not two points closer than what the resolution is) or if points are placed without
     # care for that.
-    if 'smart_filling' in request_object.args:
-        smart_filling = bool(request_object.args.get('smart_filling'))
+    if 'smart_filling' in request.args:
+        smart_filling = bool(request.args.get('smart_filling'))
     else:
         smart_filling = False
 
-    if 'distinct_points' in request_object.args:
-        keep_points = bool(request_object.args.get('distinct_points'))
+    if 'distinct_points' in request.args:
+        keep_points = bool(request.args.get('distinct_points'))
     else:
         keep_points = False
 

--- a/tests/unit_tests/test_profile.py
+++ b/tests/unit_tests/test_profile.py
@@ -166,6 +166,15 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(resp.content_type, 'application/json')
 
     @patch('app.routes.georaster_utils')
+    def test_profile_lv03_layers_post_content_type_With_charset(self, mock_georaster_utils):
+        params = create_json(4, 21781)
+        self.headers['Content-Type'] = 'application/json; charset=utf-8'
+        resp = self.prepare_mock_and_test_post(
+            mock_georaster_utils=mock_georaster_utils, body=params, expected_status=200
+        )
+        self.assertEqual(resp.content_type, 'application/json')
+
+    @patch('app.routes.georaster_utils')
     def test_profile_lv03_layers_none(self, mock_georaster_utils):
         resp = self.prepare_mock_and_test_json_profile(
             mock_georaster_utils=mock_georaster_utils,

--- a/tests/unit_tests/test_profile_validation.py
+++ b/tests/unit_tests/test_profile_validation.py
@@ -29,7 +29,6 @@ class TestProfileValidation(unittest.TestCase):
     def setUp(self) -> None:
         service_alti.app.config['TESTING'] = True
         self.test_instance = service_alti.app.test_client()
-        self.headers = DEFAULT_HEADERS
 
     def assert_response(self, response, expected_status=200):
         self.assertIsNotNone(response)
@@ -47,7 +46,7 @@ class TestProfileValidation(unittest.TestCase):
                 'nb_points': nb_points,
                 'offset': offset
             },
-            headers=self.headers
+            headers=DEFAULT_HEADERS
         )
 
     @patch('app.routes.georaster_utils')
@@ -87,6 +86,17 @@ class TestProfileValidation(unittest.TestCase):
             mock_georaster_utils=mock_georaster_utils
         )
         self.assert_response(response)
+
+    @patch('app.routes.georaster_utils')
+    def test_profile_validation_wrong_content_type(self, mock_georaster_utils):
+        prepare_mock(mock_georaster_utils)
+        response = self.test_instance.post(
+            '/rest/services/profile.json',
+            headers={
+                **DEFAULT_HEADERS, 'Content-Type': 'text/plain'
+            }
+        )
+        self.assert_response(response, expected_status=415)
 
     @patch('app.routes.georaster_utils')
     def test_profile_validation_no_linestring(self, mock_georaster_utils):


### PR DESCRIPTION
If the request was done with an invalid content-type, then the service
returned a 400, "No 'geom' given, cannot create a profile without coordinates".

This was kind of misleading, for example when doing a request with curl without
specifying the content-type (curl used application/x-www-form-urlencoded) but
with valid payload.

The issue was that request.is_json in flask is set based on the content-type header
and not on the payload being a valid json.