### PR TITLE
BGDIINF_SB-2347: Fixed callback parameter responses

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -35,14 +35,6 @@ def log_route():
     route_logger.debug('%s %s', request.method, request.path)
 
 
-@app.after_request
-def wrap_in_callback_if_present(response):
-    if "callback" in request.args:
-        response.headers['Content-Type'] = 'application/javascript'
-        response.data = f'{request.args.get("callback")}({response.get_data(as_text=True)})'
-    return response
-
-
 # Add CORS Headers to all request
 @app.after_request
 def add_cors_header(response):

--- a/tests/unit_tests/test_height.py
+++ b/tests/unit_tests/test_height.py
@@ -263,7 +263,7 @@ class TestHeight(unittest.TestCase):
             }
         )
         self.assertEqual(resp.content_type, 'application/javascript')
-        self.assertTrue('cb_({' in resp.get_data(as_text=True))
+        self.assertEqual('cb_({"height":"568.2"})', resp.get_data(as_text=True))
 
     @patch('app.routes.georaster_utils')
     def test_height_lv03_miss_northing(self, mock_georaster_utils):

--- a/tests/unit_tests/test_profile.py
+++ b/tests/unit_tests/test_profile.py
@@ -28,54 +28,26 @@ from tests.unit_tests import prepare_mock
 logger = logging.getLogger(__name__)
 
 
-class TestProfile(unittest.TestCase):
-    # pylint: disable=too-many-public-methods
+class TestProfileBase(unittest.TestCase):
 
     def setUp(self) -> None:
         service_alti.app.config['TESTING'] = True
         self.test_instance = service_alti.app.test_client()
         self.headers = DEFAULT_HEADERS
 
-    def __check_response(self, response, expected_status=200):
+    def check_response(self, response, expected_status=200):
         self.assertIsNotNone(response)
         self.assertEqual(response.status_code, expected_status, msg=response.get_data(as_text=True))
 
-    def prepare_mock_and_test_post(self, mock_georaster_utils, body, expected_status):
-        prepare_mock(mock_georaster_utils)
-        response = self.post_with_body(body)
-        self.__check_response(response, expected_status)
-        return response
-
-    def prepare_mock_and_test_csv_profile(self, mock_georaster_utils, params, expected_status):
-        prepare_mock(mock_georaster_utils)
-        response = self.get_csv_with_params(params)
-        self.__check_response(response, expected_status)
-        return response
-
-    # pylint: disable=inconsistent-return-statements
-    def get_json_profile(self, params, expected_status=200):
-        # pylint: disable=broad-except
-        try:
-            response = self.test_instance.get(
-                ENDPOINT_FOR_JSON_PROFILE, query_string=params, headers=self.headers
-            )
-            self.__check_response(response, expected_status)
-            return response
-        except Exception as e:
-            logger.exception(e)
-            self.fail(f'Call to test_instance failed: {e}')
-
-    def get_csv_with_params(self, params):
-        return self.test_instance.get(
-            ENDPOINT_FOR_CSV_PROFILE, query_string=params, headers=self.headers
+    def assert_response_contains(self, response, content):
+        self.assertTrue(
+            content in response.get_data(as_text=True),
+            msg=f"Response doesn't contain '{content}' : '{response.get_data(as_text=True)}'"
         )
 
-    def post_with_body(self, body):
-        return self.test_instance.post(ENDPOINT_FOR_JSON_PROFILE, data=body, headers=self.headers)
 
-    def prepare_mock_and_test_json_profile(self, mock_georaster_utils, params, expected_status):
-        prepare_mock(mock_georaster_utils)
-        return self.get_json_profile(params=params, expected_status=expected_status)
+class TestProfileJson(TestProfileBase):
+    # pylint: disable=too-many-public-methods
 
     def verify_point_is_present(self, response, point, msg="point not present"):
         self.assertEqual(response.content_type, "application/json")
@@ -88,11 +60,31 @@ class TestProfile(unittest.TestCase):
         if not present:
             self.fail(msg)
 
-    def assert_response_contains(self, response, content):
-        self.assertTrue(
-            content in response.get_data(as_text=True),
-            msg=f"Response doesn't contain '{content}' : '{response.get_data(as_text=True)}'"
-        )
+    def prepare_mock_and_test_json_profile(self, mock_georaster_utils, params, expected_status):
+        prepare_mock(mock_georaster_utils)
+        return self.get_json_profile(params=params, expected_status=expected_status)
+
+    def prepare_mock_and_test_post(self, mock_georaster_utils, body, expected_status):
+        prepare_mock(mock_georaster_utils)
+        response = self.post_with_body(body)
+        self.check_response(response, expected_status)
+        return response
+
+    def post_with_body(self, body):
+        return self.test_instance.post(ENDPOINT_FOR_JSON_PROFILE, data=body, headers=self.headers)
+
+    def get_json_profile(self, params, expected_status=200):
+        # pylint: disable=broad-except
+        try:
+            response = self.test_instance.get(
+                ENDPOINT_FOR_JSON_PROFILE, query_string=params, headers=self.headers
+            )
+            self.check_response(response, expected_status)
+            return response
+        except Exception as e:
+            logger.exception(e)
+            self.fail(f'Call to test_instance failed: {e}')
+        return None
 
     @patch('app.routes.georaster_utils')
     def test_do_not_fail_when_no_origin(self, mock_georaster_utils):
@@ -307,38 +299,6 @@ class TestProfile(unittest.TestCase):
         self.assertGreaterEqual(PROFILE_MAX_AMOUNT_POINTS, len(resp.json))
 
     @patch('app.routes.georaster_utils')
-    def test_profile_lv03_csv_valid(self, mock_georaster_utils):
-        resp = self.prepare_mock_and_test_csv_profile(
-            mock_georaster_utils=mock_georaster_utils,
-            params={'geom': create_json(4, 21781)},
-            expected_status=200
-        )
-        self.assertEqual(resp.content_type, 'text/csv')
-
-    @patch('app.routes.georaster_utils')
-    def test_profile_lv03_cvs_wrong_geom(self, mock_georaster_utils):
-        resp = self.prepare_mock_and_test_csv_profile(
-            mock_georaster_utils=mock_georaster_utils, params={'geom': 'toto'}, expected_status=400
-        )
-        self.assert_response_contains(resp, 'Error loading geometry in JSON string')
-
-    @patch('app.routes.georaster_utils')
-    def test_profile_lv03_csv_misspelled_shape(self, mock_georaster_utils):
-        resp = self.prepare_mock_and_test_csv_profile(
-            mock_georaster_utils=mock_georaster_utils,
-            params={'geom': LINESTRING_MISSPELLED_SHAPE},
-            expected_status=400
-        )
-        self.assert_response_contains(resp, 'Error loading geometry in JSON string')
-
-        resp = self.prepare_mock_and_test_csv_profile(
-            mock_georaster_utils=mock_georaster_utils,
-            params={'geom': LINESTRING_WRONG_SHAPE},
-            expected_status=400
-        )
-        self.assert_response_contains(resp, 'Error converting JSON to Shape')
-
-    @patch('app.routes.georaster_utils')
     def test_profile_lv03_json_invalid_linestring(self, mock_georaster_utils):
         resp = self.prepare_mock_and_test_json_profile(
             mock_georaster_utils=mock_georaster_utils,
@@ -455,3 +415,60 @@ class TestProfile(unittest.TestCase):
             self.fail("All old elevation_models must be returned in alt for compatibility issue")
         if altitudes['DTM25'] != comb_value:
             self.fail("All values from all models should be taken from the new COMB layer")
+
+
+class TestProfileCsv(TestProfileBase):
+
+    def prepare_mock_and_test_csv_profile(self, mock_georaster_utils, params, expected_status):
+        prepare_mock(mock_georaster_utils)
+        response = self.get_csv_with_params(params)
+        self.check_response(response, expected_status)
+        return response
+
+    def get_csv_with_params(self, params):
+        return self.test_instance.get(
+            ENDPOINT_FOR_CSV_PROFILE, query_string=params, headers=self.headers
+        )
+
+    @patch('app.routes.georaster_utils')
+    def test_profile_lv03_csv_valid(self, mock_georaster_utils):
+        resp = self.prepare_mock_and_test_csv_profile(
+            mock_georaster_utils=mock_georaster_utils,
+            params={'geom': create_json(4, 21781)},
+            expected_status=200
+        )
+        self.assertEqual(resp.content_type, 'text/csv')
+
+    @patch('app.routes.georaster_utils')
+    def test_profile_lv03_cvs_wrong_geom(self, mock_georaster_utils):
+        resp = self.prepare_mock_and_test_csv_profile(
+            mock_georaster_utils=mock_georaster_utils, params={'geom': 'toto'}, expected_status=400
+        )
+        self.assert_response_contains(resp, 'Error loading geometry in JSON string')
+
+    @patch('app.routes.georaster_utils')
+    def test_profile_lv03_csv_misspelled_shape(self, mock_georaster_utils):
+        resp = self.prepare_mock_and_test_csv_profile(
+            mock_georaster_utils=mock_georaster_utils,
+            params={'geom': LINESTRING_MISSPELLED_SHAPE},
+            expected_status=400
+        )
+        self.assert_response_contains(resp, 'Error loading geometry in JSON string')
+
+        resp = self.prepare_mock_and_test_csv_profile(
+            mock_georaster_utils=mock_georaster_utils,
+            params={'geom': LINESTRING_WRONG_SHAPE},
+            expected_status=400
+        )
+        self.assert_response_contains(resp, 'Error converting JSON to Shape')
+
+    @patch('app.routes.georaster_utils')
+    def test_profile_lv03_csv_callback(self, mock_georaster_utils):
+        resp = self.prepare_mock_and_test_csv_profile(
+            mock_georaster_utils=mock_georaster_utils,
+            params={
+                'geom': create_json(4, 21781), 'callback': '_cb'
+            },
+            expected_status=400
+        )
+        self.assert_response_contains(resp, 'callback parameter not supported')


### PR DESCRIPTION
The callback query parameter has two minor issues and was also not very efficient
when used on the profile.json endpoint.

The first issue was that if given to the profile.csv endpoint it would have
transformed the CSV output by wrapping it with the value of callback and
marked the output as javascript. However this was an invalid javascript output
as CSV is not a javascript valid syntax. This bug has been introduced with the
dockerization, before in this case the callback query was simply ignored. Now
it is not ignored but returns a 400 HTTP status.

The second minor issue, which was more a syntax sugar, was that using the callback
query, a useless LF character was added at the end of the json data.

The last issue was about efficiency especially used on a big data output (200 points).
Although I did not measure the time penalty (so it might have been negligible),
I change it to be more efficient and it make also IMHO the code cleaner.
The issue was that the data in the response object is binary and due to the
implicit call of Flask make_response for a JSON output the `\n` LF character
was added. So using the `after_response` flask hook did introduced an unwanted
`\n` see above but also the profile.json behavior see above as well, in this
hook we had to decode and parse the binary output again and then to encode it
again. So now without using this hook we change the output to javascript
before encoding it with `make_response`. This is slightly more efficient and
require lest IO and CPU.