### PR TITLE
BGDIINF_SB-2374: Fixed profile height

### DIFF
--- a/app/helpers/validation/profile.py
+++ b/app/helpers/validation/profile.py
@@ -113,7 +113,7 @@ def read_spatial_reference(linestring):
 def read_offset():
     # param offset, used for smoothing. define how many coordinates should be included
     # in the window used for smoothing. If value is zero smoothing is disabled.
-    offset = 3
+    offset = 0
     if 'offset' in request.args:
         offset = request.args.get('offset')
         if offset.isdigit():


### PR DESCRIPTION
When no offset is given in URL query parameter we need to disable smoothing
by setting the offset to 3. This bug has been introduced with the migration
to flask, before the default value was None.