### PR TITLE
BGDIINF_SB-2383 check for wrong geometry type

### DIFF
--- a/app/helpers/validation/profile.py
+++ b/app/helpers/validation/profile.py
@@ -45,7 +45,9 @@ def read_linestring():
         geom_to_shape.is_valid
     # pylint: disable=broad-except
     except Exception:
-        abort(400, "Invalid Linestring syntax")
+        abort(400, "Invalid geometry syntax")
+    if geom_to_shape.geom_type != 'LineString':
+        abort(400, "Geometry must be a 'LineString'")
     if len(geom_to_shape.coords) > PROFILE_MAX_AMOUNT_POINTS:
         abort(
             413,

--- a/tests/unit_tests/__init__.py
+++ b/tests/unit_tests/__init__.py
@@ -35,6 +35,11 @@ LINESTRING_WRONG_SHAPE = '{"type":"OneShape","coordinates":[[550050,206550],[556
 LINESTRING_MISSPELLED_SHAPE = '{"type":"OneShape","coordinates":[[550050,206550],[556950,204150],' \
                               '[561050,207950]]'
 
+MULTILINESTRING_VALID_LV03 = '{"type": "MultiLineString", "coordinates": [' \
+                             f'[{POINT_1_LV03}, {POINT_3_LV03}, {POINT_2_LV03}],' \
+                             f'[{POINT_2_LV03}, {POINT_2_LV03}]' \
+                             ']}'
+
 
 def fake_get_height_for_coordinate(_, y):
     return VALUES_FOR_EACH_2M_STEP[int(int(y - 1199980) / 2) % 11]

--- a/tests/unit_tests/test_profile_validation.py
+++ b/tests/unit_tests/test_profile_validation.py
@@ -11,7 +11,7 @@ with patch('os.path.exists') as mock_exists:
 from app.helpers.profile_helpers import PROFILE_DEFAULT_AMOUNT_POINTS
 from app.helpers.profile_helpers import PROFILE_MAX_AMOUNT_POINTS
 from tests import create_json
-from tests.unit_tests import DEFAULT_HEADERS
+from tests.unit_tests import DEFAULT_HEADERS, MULTILINESTRING_VALID_LV03
 from tests.unit_tests import prepare_mock
 
 logger = logging.getLogger(__name__)
@@ -62,6 +62,17 @@ class TestProfileValidation(unittest.TestCase):
             self.assert_response(response)
             profile = response.get_json()
             self.assertEqual(VALID_NB_POINTS, len(profile))
+
+    @patch('app.routes.georaster_utils')
+    def test_profile_validation_invalid_geometry_type(self, mock_georaster_utils):
+        response = self.prepare_mock_and_test(
+            linestring=MULTILINESTRING_VALID_LV03,
+            spatial_reference=VALID_SPATIAL_REFERENCES[0],
+            nb_points=None,
+            offset=VALID_OFFSET,
+            mock_georaster_utils=mock_georaster_utils
+        )
+        self.assert_response(response, expected_status=400)
 
     @patch('app.routes.georaster_utils')
     def test_profile_validation_valid_nb_points_none(self, mock_georaster_utils):


### PR DESCRIPTION
Currently, the validationb does check for the geometry type, so any valid GeoJSON will be turned into `shapely` and error might/will occur.