### PR TITLE
BGDIINF_SB-2347: Improved error message in case of invalid nb_points

### DIFF
--- a/app/helpers/validation/profile.py
+++ b/app/helpers/validation/profile.py
@@ -70,16 +70,18 @@ def read_number_points():
     else:
         nb_points = PROFILE_DEFAULT_AMOUNT_POINTS
 
-    if (isinstance(nb_points, int) or nb_points.isdigit()) and int(nb_points) <= 1:
+    try:
+        nb_points = int(nb_points)
+    except ValueError:
+        abort(400, "Please provide a numerical value for the parameter 'NbPoints'/'nb_points'")
+
+    if nb_points <= 1:
         abort(
             400,
             "Please provide a numerical value for the parameter 'NbPoints'/'nb_points' greater "
             "or equal to 2"
         )
-    if (isinstance(nb_points, int) or
-        nb_points.isdigit()) and int(nb_points) <= PROFILE_MAX_AMOUNT_POINTS:
-        nb_points = int(nb_points)
-    else:
+    if nb_points > PROFILE_MAX_AMOUNT_POINTS:
         abort(
             400,
             "Please provide a numerical value for the parameter 'NbPoints'/'nb_points'"

--- a/tests/unit_tests/test_profile_validation.py
+++ b/tests/unit_tests/test_profile_validation.py
@@ -165,7 +165,7 @@ class TestProfileValidation(unittest.TestCase):
         self.assert_response(response, expected_status=400)
 
     @patch('app.routes.georaster_utils')
-    def test_profile_validation_nb_points_not_int(self, mock_georaster_utils):
+    def test_profile_validation_invalid_nb_points(self, mock_georaster_utils):
         response = self.prepare_mock_and_test(
             linestring=create_json(2),
             spatial_reference=VALID_SPATIAL_REFERENCES[0],
@@ -174,6 +174,39 @@ class TestProfileValidation(unittest.TestCase):
             mock_georaster_utils=mock_georaster_utils
         )
         self.assert_response(response, expected_status=400)
+        self.assertEqual(
+            response.json['error']['message'],
+            'Please provide a numerical value for the parameter '
+            "'NbPoints'/'nb_points'"
+        )
+
+        response = self.prepare_mock_and_test(
+            linestring=create_json(2),
+            spatial_reference=VALID_SPATIAL_REFERENCES[0],
+            nb_points=0,
+            offset=VALID_OFFSET,
+            mock_georaster_utils=mock_georaster_utils
+        )
+        self.assert_response(response, expected_status=400)
+        self.assertEqual(
+            response.json['error']['message'],
+            'Please provide a numerical value for the parameter '
+            "'NbPoints'/'nb_points' greater or equal to 2"
+        )
+
+        response = self.prepare_mock_and_test(
+            linestring=create_json(2),
+            spatial_reference=VALID_SPATIAL_REFERENCES[0],
+            nb_points=-1,
+            offset=VALID_OFFSET,
+            mock_georaster_utils=mock_georaster_utils
+        )
+        self.assert_response(response, expected_status=400)
+        self.assertEqual(
+            response.json['error']['message'],
+            'Please provide a numerical value for the parameter '
+            "'NbPoints'/'nb_points' greater or equal to 2"
+        )
 
     @patch('app.routes.georaster_utils')
     def test_profile_validation_offset_not_int(self, mock_georaster_utils):


### PR DESCRIPTION
In case of a nb_points smaller than 2, the error message was that the value must
be smaller than 5000 which was missleading as 0 or -1 is smaller than 5000.

Now the error message says that the nb_points must be greater than 1.