### PR TITLE
BGDIINF_SB-2477: Fixed support for form url encoded input data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ VENV := $(shell pipenv --venv)
 
 # default configuration
 HTTP_PORT ?= 5000
-DTM_BASE_PATH ?= $(CURRENT_DIR)
+# For the DTM_BASE_PATH use the one in development.bgdi.ch server as default
+DTM_BASE_PATH ?= /var/local/efs-dev/geodata/bund/swisstopo/
 LOGS_DIR ?= $(CURRENT_DIR)/logs
 
 # Commands
@@ -124,7 +125,7 @@ format-lint: format lint
 .PHONY: test
 test:
 	mkdir -p $(TEST_REPORT_DIR)
-	DTM_BASE_PATH=$(DTM_BASE_PATH) $(NOSE) \
+	DTM_BASE_PATH=$(CURRENT_DIR) $(NOSE) \
 		-c tests/unittest.cfg \
 		--verbose \
 		--junit-xml-path $(TEST_REPORT_DIR)/$(TEST_REPORT_FILE) \

--- a/app/helpers/validation/profile.py
+++ b/app/helpers/validation/profile.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from distutils.util import strtobool
 
 import geojson
 from shapely.geometry import shape
@@ -7,7 +8,6 @@ from shapely.geometry import shape
 from flask import abort
 from flask import request
 
-from app.helpers.profile_helpers import PROFILE_DEFAULT_AMOUNT_POINTS
 from app.helpers.profile_helpers import PROFILE_MAX_AMOUNT_POINTS
 from app.helpers.validation import srs_guesser
 from app.helpers.validation import validate_sr
@@ -18,16 +18,24 @@ max_content_length = 32 * 1024 * 1024  # 32MB
 PROFILE_VALID_GEOMETRY_TYPES = ['LineString', 'Point']
 
 
-def read_linestring():
+def get_args():
+    args = dict(request.args)
+    if request.method == 'POST':
+        if request.content_type != "application/x-www-form-urlencoded" and not request.is_json:
+            abort(415, f'{request.content_type} non allowed')
+        if request.content_type == "application/x-www-form-urlencoded":
+            args.update(request.form)
+    return args
+
+
+def read_linestring(args):
     # param geom, list of coordinates defining the line on which we want a profile
     linestring = None
     geom = None
     geom_to_shape = None
-    if 'geom' in request.args:
-        linestring = request.args.get('geom')
-    elif request.method == 'POST':
-        if not request.is_json:
-            abort(415)
+    if 'geom' in args:
+        linestring = args.get('geom')
+    elif request.method == 'POST' and request.is_json:
         if request.content_length and 0 < request.content_length < max_content_length:
             linestring = request.get_data(as_text=True)  # read as text
 
@@ -61,49 +69,45 @@ def read_linestring():
     return geom_to_shape
 
 
-def read_number_points():
+def read_number_points(args):
     # number of points wanted in the final profile.
-    if 'nbPoints' in request.args:
-        nb_points = request.args.get('nbPoints')
-    elif 'nb_points' in request.args:
-        nb_points = request.args.get('nb_points')
+    if 'nbPoints' in args:
+        nb_points = args['nbPoints']
+    elif 'nb_points' in args:
+        nb_points = args['nb_points']
     else:
-        nb_points = PROFILE_DEFAULT_AMOUNT_POINTS
+        nb_points = None
 
-    try:
-        nb_points = int(nb_points)
-    except ValueError:
-        abort(400, "Please provide a numerical value for the parameter 'NbPoints'/'nb_points'")
+    if nb_points is not None:
+        try:
+            nb_points = int(nb_points)
+        except ValueError:
+            abort(400, "Please provide a numerical value for the parameter 'NbPoints'/'nb_points'")
 
-    if nb_points <= 1:
-        abort(
-            400,
-            "Please provide a numerical value for the parameter 'NbPoints'/'nb_points' greater "
-            "or equal to 2"
-        )
-    if nb_points > PROFILE_MAX_AMOUNT_POINTS:
-        abort(
-            400,
-            "Please provide a numerical value for the parameter 'NbPoints'/'nb_points'"
-            f" smaller than {PROFILE_MAX_AMOUNT_POINTS}"
-        )
+        if nb_points <= 1:
+            abort(
+                400,
+                "Please provide a numerical value for the parameter 'NbPoints'/'nb_points' greater "
+                "or equal to 2"
+            )
+        if nb_points > PROFILE_MAX_AMOUNT_POINTS:
+            abort(
+                400,
+                "Please provide a numerical value for the parameter 'NbPoints'/'nb_points'"
+                f" smaller than {PROFILE_MAX_AMOUNT_POINTS}"
+            )
     return nb_points
 
 
-def read_is_custom_nb_points():
-    # number of points wanted in the final profile.
-    return 'nbPoints' in request.args or 'nb_points' in request.args
-
-
-def read_spatial_reference(linestring):
+def read_spatial_reference(linestring, args):
     # param sr (or projection, sr meaning spatial reference), which Swiss projection to use.
     # Possible values are expressed in int, so value for EPSG:2056 (LV95) is 2056
     # and value for EPSG:21781 (LV03) is 21781. If this param is not present, it will be guessed
     # from the coordinates present in the param geom
-    if 'sr' in request.args:
-        spatial_reference = int(request.args.get('sr'))
-    elif 'projection' in request.args:
-        spatial_reference = int(request.args.get('projection'))
+    if 'sr' in args:
+        spatial_reference = int(args.get('sr'))
+    elif 'projection' in args:
+        spatial_reference = int(args.get('projection'))
     else:
         sr = srs_guesser(linestring)
         if sr is None:
@@ -114,14 +118,50 @@ def read_spatial_reference(linestring):
     return spatial_reference
 
 
-def read_offset():
+def read_offset(args):
     # param offset, used for smoothing. define how many coordinates should be included
     # in the window used for smoothing. If value is zero smoothing is disabled.
     offset = 0
-    if 'offset' in request.args:
-        offset = request.args.get('offset')
+    if 'offset' in args:
+        offset = args.get('offset')
         if offset.isdigit():
             offset = int(offset)
         else:
             abort(400, "Please provide a numerical value for the parameter 'offset'")
     return offset
+
+
+def read_only_requested_points(args):
+    if 'only_requested_points' in args:
+        try:
+            only_requested_points = strtobool(args.get('only_requested_points'))
+        except ValueError as error:
+            logger.error('Invalid value for "only_requested_points" argument: %s', error)
+            abort(400, f'Invalid value for "only_requested_points" argument: {error}')
+    else:
+        only_requested_points = False
+    return only_requested_points
+
+
+def read_smart_filling(args):
+    if 'smart_filling' in args:
+        try:
+            smart_filling = strtobool(args.get('smart_filling'))
+        except ValueError as error:
+            logger.error('Invalid value for "smart_filling" argument: %s', error)
+            abort(400, f'Invalid value for "smart_filling" argument: {error}')
+    else:
+        smart_filling = False
+    return smart_filling
+
+
+def read_distinct_points(args):
+    if 'distinct_points' in args:
+        try:
+            keep_points = strtobool(args.get('distinct_points'))
+        except ValueError as error:
+            logger.error('Invalid value for "distinct_points" argument: %s', error)
+            abort(400, f'Invalid value for "distinct_points" argument: {error}')
+    else:
+        keep_points = False
+    return keep_points


### PR DESCRIPTION
The profile.json|csv should have supported input as form url encoded. This
was not the case.

Now all input parameters can be given as POST body in
application/x-www-form-urlencoded form. The JSON body in opposite only
accept the geom parameter.
Url encoded form parameter overwrite the parameter in query string.