### PR TITLE
BGDIINF_SB-2544: Added readiness probe and curl for liveness probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,13 @@ RUN groupadd -g 1000 geoadmin && useradd -u 1000 -s /bin/false -g geoadmin geoad
 
 
 # HERE : install relevant packages
-RUN pip3 install pipenv \
+# NOTE: curl is required for vhost health check, could be removed when moving to k8s
+RUN apt-get update \
+  && apt-get -y install \
+       curl \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && pip3 install pipenv \
     && pipenv --version
 
 COPY Pipfile* /tmp/

--- a/app/helpers/raster/georaster.py
+++ b/app/helpers/raster/georaster.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 from os.path import dirname
+from pathlib import Path
 from struct import unpack
 
 from app.helpers.raster.shputils import SHPUtils
@@ -58,6 +59,12 @@ class GeoRasterUtils(object):
                     e
                 )
                 raise e
+
+    def raster_files_exists(self):
+        for f in self.raster_files.values():
+            if not Path(f).exists():
+                return False
+        return True
 
 
 class BinaryTerrainTile(object):

--- a/app/routes.py
+++ b/app/routes.py
@@ -24,7 +24,6 @@ from app.helpers.validation import bboxes
 from app.helpers.validation import srs_guesser
 from app.helpers.validation import validate_sr
 from app.helpers.validation.height import validate_lon_lat
-# add route prefix
 from app.statistics.statistics import load_json
 from app.statistics.statistics import prepare_data
 from app.version import APP_VERSION
@@ -45,8 +44,16 @@ def handle_exception(e):
 
 
 @app.route('/checker')
-def check():
+def liveness():
     return make_response(jsonify({'success': True, 'message': 'OK', 'version': APP_VERSION}))
+
+
+@app.route('/checker/ready')
+def readiness():
+    # Make sure the data are available
+    if not georaster_utils.raster_files_exists():
+        abort(503, "No raster files found")
+    return make_response(jsonify({'success': True, 'message': 'OK'}))
 
 
 @app.route('/height')

--- a/tests/unit_tests/test_checker.py
+++ b/tests/unit_tests/test_checker.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from flask.helpers import url_for
 
 from tests.unit_tests import DEFAULT_EXTERN_HEADERS
@@ -7,14 +9,40 @@ from tests.unit_tests.base import BaseRouteTestCase
 
 class CheckerTests(BaseRouteTestCase):
 
-    def __checker_test_get_request(self, headers):
-        response = self.test_instance.get(url_for('check'), headers=headers)
+    def __liveness_test_get_request(self, headers):
+        response = self.test_instance.get(url_for('liveness'), headers=headers)
         self.check_response(response)
         self.assertNotIn('Cache-Control', response.headers)
         self.assertEqual(response.content_type, "application/json")
 
-    def test_checker_intern_origin(self):
-        self.__checker_test_get_request(DEFAULT_INTERN_HEADERS)
+    def __readiness_test_get_request(self, headers, expected_status=200):
+        response = self.test_instance.get(url_for('readiness'), headers=headers)
+        self.check_response(response, expected_status=expected_status)
+        self.assertNotIn('Cache-Control', response.headers)
+        self.assertEqual(response.content_type, "application/json")
 
-    def test_checker_extern_origin(self):
-        self.__checker_test_get_request(DEFAULT_EXTERN_HEADERS)
+    def test_liveness_intern_origin(self):
+        self.__liveness_test_get_request(DEFAULT_INTERN_HEADERS)
+
+    def test_liveness_extern_origin(self):
+        self.__liveness_test_get_request(DEFAULT_EXTERN_HEADERS)
+
+    def test_liveness_no_origin(self):
+        self.__liveness_test_get_request(None)
+
+    def test_readiness_not_ready(self):
+        self.__readiness_test_get_request(None, expected_status=503)
+
+    @mock.patch(
+        'app.routes.georaster_utils.raster_files_exists',
+    )
+    def test_readiness_no_origin(self, mock_raster_files_exists):
+        mock_raster_files_exists.return_value = True
+        self.__readiness_test_get_request(None)
+
+    @mock.patch(
+        'app.routes.georaster_utils.raster_files_exists',
+    )
+    def test_readiness_extern_origin(self, mock_raster_files_exists):
+        mock_raster_files_exists.return_value = True
+        self.__readiness_test_get_request(DEFAULT_EXTERN_HEADERS)


### PR DESCRIPTION
On vhost we need to have curl in order to test the liveness probe. Curl can
be in future removed when migrating to k8s.