### PR TITLE
BGDIINF_SB-2879: Added cache-control header

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,4 @@ The service is configured by Environment Variable:
 | DTM_BASE_PATH        | `'/var/local/profile/'`   | Raster and COMB files location         |
 | PRELOAD_RASTER_FILES | `False`                   | Preload raster files at startup. If not set they will be loaded during first request |
 | ALTI_WORKERS         | `0`                       | Number of workers. `0` or negative value means that the number of worker are computed from the number of cpu |
+| DFT_CACHE_HEADER     | `public, max-age=86400`   | Default cache settings for successful GET, HEAD and OPTIONS requests |

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -59,6 +59,8 @@ def add_cache_header(response):
     # short cache duration for other 5xx errors
     elif response.status_code >= 500:
         response.headers['Cache-Control'] = 'public, max-age=10'
+    else:
+        response.headers['Cache-Control'] = settings.DFT_CACHE_HEADER
     return response
 
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -12,6 +12,7 @@ LOGGING_CFG = os.getenv('LOGGING_CFG', 'logging-cfg-local.yml')
 
 DTM_BASE_PATH = Path(os.getenv('DTM_BASE_PATH', '/var/local/profile/'))
 PRELOAD_RASTER_FILES = strtobool(os.getenv('PRELOAD_RASTER_FILES', 'False'))
+DFT_CACHE_HEADER = os.getenv('DFT_CACHE_HEADER', 'public, max-age=86400')
 
 TRAP_HTTP_EXCEPTIONS = True
 

--- a/tests/unit_tests/test_checker.py
+++ b/tests/unit_tests/test_checker.py
@@ -12,20 +12,11 @@ class CheckerTests(BaseRouteTestCase):
     def __liveness_test_get_request(self, headers):
         response = self.test_instance.get(url_for('liveness'), headers=headers)
         self.check_response(response)
-        self.assertNotIn('Cache-Control', response.headers)
         self.assertEqual(response.content_type, "application/json")
 
     def __readiness_test_get_request(self, headers, expected_status=200):
         response = self.test_instance.get(url_for('readiness'), headers=headers)
         self.check_response(response, expected_status=expected_status)
-        if expected_status < 500:
-            self.assertNotIn('Cache-Control', response.headers)
-        elif expected_status in (502, 503, 504, 507):
-            self.assertIn('Cache-Control', response.headers)
-            self.assertIn('no-cache', response.headers['Cache-Control'])
-        elif expected_status >= 500:
-            self.assertIn('Cache-Control', response.headers)
-            self.assertIn('max-age', response.headers['Cache-Control'])
         self.assertEqual(response.content_type, "application/json")
 
     def test_liveness_intern_origin(self):

--- a/tests/unit_tests/test_height.py
+++ b/tests/unit_tests/test_height.py
@@ -50,6 +50,18 @@ class TestHeight(BaseRouteTestCase):
         )
 
     @patch('app.routes.georaster_utils')
+    def test_cache_header(self, mock_georaster_utils):
+        response = self.__prepare_mock_and_test_get(
+            mock_georaster_utils=mock_georaster_utils,
+            params={
+                'easting': EAST_LV95, 'northing': NORTH_LV95
+            }
+        )
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('public', response.headers['Cache-Control'])
+        self.assertIn('max-age=', response.headers['Cache-Control'])
+
+    @patch('app.routes.georaster_utils')
     def test_height_no_sr_assuming_lv03(self, mock_georaster_utils):
         self.__assert_height(
             response=self.__prepare_mock_and_test_get(

--- a/tests/unit_tests/test_profile.py
+++ b/tests/unit_tests/test_profile.py
@@ -101,6 +101,19 @@ class TestProfileJson(TestProfileBase):
         )
 
     @patch('app.routes.georaster_utils')
+    def test_cache_header(self, mock_georaster_utils):
+        response = self.prepare_mock_and_test_get(
+            mock_georaster_utils=mock_georaster_utils,
+            params={
+                'sr': 2056, 'geom': create_json(4, 2056)
+            },
+            expected_status=200
+        )
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('public', response.headers['Cache-Control'])
+        self.assertIn('max-age=', response.headers['Cache-Control'])
+
+    @patch('app.routes.georaster_utils')
     def test_profile_invalid_sr_json_valid(self, mock_georaster_utils):
         resp = self.prepare_mock_and_test_get(
             mock_georaster_utils=mock_georaster_utils,


### PR DESCRIPTION
We experienced on our e2e tests issues with caching where we had unexpected
miss from cache. A first analyze showed us that the service did not set any
cache-control header, so in theory CF would use the default TTL of the cache
policy. Anyway it is better to control cache from the service and not from CF.