### PR TITLE
Feat pb 569 switch to docker compose plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,11 +181,6 @@ dockerrun:
 		$(DOCKER_IMG_LOCAL_TAG)
 
 
-.PHONY: shutdown
-shutdown:
-	HTTP_PORT=$(HTTP_PORT) docker compose down
-
-
 # Clean targets
 
 .PHONY: clean_venv

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ dockerrun:
 
 .PHONY: shutdown
 shutdown:
-	HTTP_PORT=$(HTTP_PORT) docker-compose down
+	HTTP_PORT=$(HTTP_PORT) docker compose down
 
 
 # Clean targets

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Height and profile services for http://api3.geo.admin.ch
 
 ### Dependencies
 
-The **Make** targets assume you have **bash**, **curl**, **python3.9**, **pipenv**, **docker** and **docker-compose-plugin** installed.
+The **Make** targets assume you have **bash**, **curl**, **python3.9**, **pipenv**, **docker** installed.
 
 ### Setting up to work
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Height and profile services for http://api3.geo.admin.ch
 
 ### Dependencies
 
-The **Make** targets assume you have **bash**, **curl**, **python3.9**, **pipenv**, **docker** and **docker-compose** installed.
+The **Make** targets assume you have **bash**, **curl**, **python3.9**, **pipenv**, **docker** and **docker-compose-plugin** installed.
 
 ### Setting up to work
 


### PR DESCRIPTION
At first, I updated `docker-compose` to be `docker compose`, then I noticed that the occurence of `docker-compose` was probably just a copy&paste mistake back in the day the project was created. There is no `docker-compose.yml` file in this project.