### PR TITLE
BGDIDIC-1950: increase perimeter

### DIFF
--- a/app/helpers/validation/__init__.py
+++ b/app/helpers/validation/__init__.py
@@ -10,17 +10,17 @@ from app.settings import VALID_SRID
 bboxes = {
     2056:
         (
-            float_raise_nan(2450000),
-            float_raise_nan(1030000),
-            float_raise_nan(2900000),
-            float_raise_nan(1350000)
+            float_raise_nan(2385000),  # xmin: expanded to cover old and new
+            float_raise_nan(974000),  # ymin: expanded to cover old and new
+            float_raise_nan(2935000),  # xmax: expanded to cover old and new
+            float_raise_nan(1404000)  # ymax: expanded to cover old and new
         ),
     21781:
         (
-            float_raise_nan(450000),
-            float_raise_nan(30000),
-            float_raise_nan(900000),
-            float_raise_nan(350000)
+            float_raise_nan(385000),  # xmin: expanded to cover old and new
+            float_raise_nan(-26000),  # ymin: expanded to cover old and new
+            float_raise_nan(940000),  # xmax: expanded to cover old and new
+            float_raise_nan(456000)  # ymax: expanded to cover old and new
         )
 }
 

--- a/tests/unit_tests/test_height.py
+++ b/tests/unit_tests/test_height.py
@@ -164,7 +164,7 @@ class TestHeight(BaseRouteTestCase):
         resp = self.__prepare_mock_and_test_get(
             mock_georaster_utils=mock_georaster_utils,
             params={
-                'easting': '600000', 'northing': '0'
+                'easting': '600000', 'northing': '-100000'
             },
             expected_status=400
         )


### PR DESCRIPTION
with the latest data update the perimeter covered by swissalti has been increased. these changes are updating the service perimeter from:
`Extent: (2450000.000000, 1030000.000000) - (2900000.000000, 1350000.000000)`
to:
`Extent: (2385000.000000, 974000.000000) - (2935000.000000, 1404000.000000) `
